### PR TITLE
LPS-69135

### DIFF
--- a/modules/apps/foundation/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/messaging/ConfigurationMessageListener.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/messaging/ConfigurationMessageListener.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.StringBundler;
 
+import java.util.Dictionary;
+
 import org.osgi.framework.Constants;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -76,6 +78,9 @@ public class ConfigurationMessageListener extends BaseMessageListener {
 
 		_reloadablePersistenceManager.reload(pid);
 
+		Dictionary<String, ?> properties = _reloadablePersistenceManager.load(
+			pid);
+
 		try {
 			ConfigurationThreadLocal.setLocalUpdate(true);
 
@@ -91,7 +96,12 @@ public class ConfigurationMessageListener extends BaseMessageListener {
 					configuration.delete();
 				}
 				else {
-					configuration.update();
+					if (properties == null) {
+						configuration.update();
+					}
+					else {
+						configuration.update(properties);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Hey @drewbrokke,

Looks like you were right to be concerned about the removal of the properties. When creating a new configuration, the properties are necessary in order to update the other nodes. I am still including a null check though so that null properties are not overwriting valid ones, which was necessary for the previous fix. If you want an environment to test this in, please let me know.

Thanks!