### PR TITLE
[TS] LPS-78127

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/PortletPreferencesModelListener.java
+++ b/portal-impl/src/com/liferay/portal/model/PortletPreferencesModelListener.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
@@ -31,6 +32,7 @@ import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.servlet.filters.cache.CacheUtil;
 
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * @author Alexander Chow
@@ -38,6 +40,19 @@ import java.util.Date;
  */
 public class PortletPreferencesModelListener
 	extends BaseModelListener<PortletPreferences> {
+
+	@Override
+	public void onAfterCreate(PortletPreferences portletPreferences) {
+		if ((portletPreferences.getOwnerType() ==
+				PortletKeys.PREFS_OWNER_TYPE_GROUP) &&
+			(portletPreferences.getOwnerId() > 0) &&
+			!Objects.equals(
+				portletPreferences.getPreferences(),
+				PortletConstants.DEFAULT_PREFERENCES)) {
+
+			updateLayout(portletPreferences);
+		}
+	}
 
 	@Override
 	public void onAfterRemove(PortletPreferences portletPreferences) {


### PR DESCRIPTION
Hi @drewbrokke 

Hope you are well.

I am Hai from DaLian office in China. Since we are in the Spring Festival holiday, so I skip my the reviewer Hugo and send the PR to you to review.

The root issue is when portletId is service name (for example, "com.liferay.blogs") and save its configuratuion in site template, **due to LayoutSetPrototype's modifiedDate doesn't be update**, so that merge won't occur. Please refer to https://github.com/yuhai/liferay-portal/blob/LPS-78127/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java#L1086

For the portletId "com.liferay.blogs", when save its configuration and its related portletpreferences data will  be created. So the fix only is for the kind of portletId's configuration so that the configuration can be propagated from site template to the site.

For the condition
```
!Objects.equals(portletPreferences.getPreferences(),PortletConstants.DEFAULT_PREFERENCES)
```
It will skip the kind of portletId "com_liferay_blogs_web_portlet_BlogsAdminPortlet"'s portletPreferences. Because when go to Content > Message Boards > ⋮ button on the right top corner > Configuration, the kind of portletId's portletPreferences will be created. In this case, LayoutSetPrototype's modifiedDate shouldn't be updated.

Regards,
Hai