### PR TITLE
[TECHNICAL-SUPPORT] LPS-82175

### DIFF
--- a/portal-impl/src/com/liferay/portlet/usersadmin/util/OrganizationIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/util/OrganizationIndexer.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
@@ -117,6 +118,8 @@ public class OrganizationIndexer extends BaseIndexer<Organization> {
 
 			for (Organization organization : organizationsTree) {
 				String treePath = organization.buildTreePath();
+
+				treePath = StringUtil.quote(treePath, StringPool.STAR);
 
 				WildcardQuery wildcardQuery = new WildcardQueryImpl(
 					Field.TREE_PATH, treePath);


### PR DESCRIPTION
/cc @Alec-Shay

Notes from Alec:

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-30258
> https://issues.liferay.com/browse/LPS-82175
> 
> Fixing an issue where searching for sub-organizations from parent Organizations returns no results.
> 
> We were not able to reproduce this issue in master; this may partly be because of Elasticsearch 6 being the default in master, unlike 7.0.x, but testing with this changed (following the [steps outlined here](https://grow.liferay.com/people/Default+Search+Engine+is+Elasticsearch+6+on+Master) I was still not able to test the issue because another issue with newly created Organizations not showing up blocked it).
> 
> However, this was found to fix the issue in 7.0.x, and the relevant code is still present in master, so I am submitting it here first. If there are any problems found with this or concerns with the fix, please let me know. Thank you!