### PR TITLE
LPS-83255 Clarify and deprecate search.container.show.pagination prop…

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1540,10 +1540,22 @@ public class PropsValues {
 
 	public static final int SEARCH_CONTAINER_PAGE_ITERATOR_MAX_PAGES = GetterUtil.getInteger(PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_ITERATOR_MAX_PAGES));
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final boolean SEARCH_CONTAINER_SHOW_PAGINATION_BOTTOM = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SEARCH_CONTAINER_SHOW_PAGINATION_BOTTOM));
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final boolean SEARCH_CONTAINER_SHOW_PAGINATION_TOP = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SEARCH_CONTAINER_SHOW_PAGINATION_TOP));
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final int SEARCH_CONTAINER_SHOW_PAGINATION_TOP_DELTA = GetterUtil.getInteger(PropsUtil.get(PropsKeys.SEARCH_CONTAINER_SHOW_PAGINATION_TOP_DELTA), 10);
 
 	public static final String[] SERVLET_SERVICE_EVENTS_POST = PropsUtil.getArray(PropsKeys.SERVLET_SERVICE_EVENTS_POST);

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6994,12 +6994,20 @@
     search.container.page.iterator.max.pages=25
 
     #
+    # These properties are deprecated and will be removed in a future release,
+    # they only affect the small number of searches still using legacy markup
+    # such as Define Role Permissions and Knowledge Base Search.
+    #
     # Set this to false to remove the pagination controls above or below
-    # results.
+    # results on the Roles Define Permissions page.
     #
     search.container.show.pagination.top=true
     search.container.show.pagination.bottom=true
 
+    #
+    # This property is deprecated and will be removed in a future release,
+    # they only affect the small number of searches still using legacy markup
+    # such as Define Role Permissions and Knowledge Base Search.
     #
     # Set the number of entries to display per page for top pagination controls.
     # The property "search.container.show.pagination.top" must also be set to

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2113,10 +2113,22 @@ public interface PropsKeys {
 
 	public static final String SEARCH_CONTAINER_PAGE_ITERATOR_MAX_PAGES = "search.container.page.iterator.max.pages";
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String SEARCH_CONTAINER_SHOW_PAGINATION_BOTTOM = "search.container.show.pagination.bottom";
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String SEARCH_CONTAINER_SHOW_PAGINATION_TOP = "search.container.show.pagination.top";
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String SEARCH_CONTAINER_SHOW_PAGINATION_TOP_DELTA = "search.container.show.pagination.top.delta";
 
 	public static final String SERVLET_SERVICE_EVENTS_POST = "servlet.service.events.post";


### PR DESCRIPTION
…erties
https://issues.liferay.com/browse/LPS-83255
https://issues.liferay.com/browse/LPP-30788

These properties are only used in non-lexicon searches. They were previously used in the other pages in Users, Organizations, and Roles added here: https://issues.liferay.com/browse/LPS-44220 - however the UI of the other pages has changed and most searches (places where users can enter terms) now use lexicon. Because of the limit of their scope along with the generality of their description, customers were expecting much more from these properties.

Note: the description needs to be updated in the Japanese portal properties as well.