### PR TITLE
LPS-86711 An apostrophe in users.screen.name.special.characters causes all buttons on the same page as the user's screenname field to no longer function

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/security/auth/DefaultScreenNameValidatorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/DefaultScreenNameValidatorTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.auth;
+
+import com.liferay.portal.kernel.security.auth.DefaultScreenNameValidator;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.util.HtmlImpl;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class DefaultScreenNameValidatorTest extends DefaultScreenNameValidator {
+
+	@Before
+	public void setUp() {
+		HtmlUtil htmlUtil = new HtmlUtil();
+
+		htmlUtil.setHtml(new HtmlImpl());
+	}
+
+	@Test
+	public void testGetJSEscapedSpecialChars() {
+		_specialCharacters = "-._'";
+
+		Assert.assertEquals(
+			HtmlUtil.escapeJS(_specialCharacters), getJSEscapedSpecialChars());
+	}
+
+	@Override
+	protected String getSpecialChars() {
+		return _specialCharacters;
+	}
+
+	private String _specialCharacters = "-._";
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/DefaultScreenNameValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/DefaultScreenNameValidator.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.security.auth;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -33,7 +34,7 @@ public class DefaultScreenNameValidator implements ScreenNameValidator {
 	@Override
 	public String getAUIValidatorJS() {
 		return "function(val) {var pattern = new RegExp('[^A-Za-z0-9" +
-			getSpecialChars() +
+			getJSEscapedSpecialChars() +
 				"]');if (val.match(pattern)) {return false;}return true;}";
 	}
 
@@ -57,6 +58,16 @@ public class DefaultScreenNameValidator implements ScreenNameValidator {
 		return true;
 	}
 
+	protected String getJSEscapedSpecialChars() {
+		if (_jsEscapedSpecialChars == null) {
+			_jsEscapedSpecialChars = getSpecialChars();
+
+			_jsEscapedSpecialChars = HtmlUtil.escapeJS(_jsEscapedSpecialChars);
+		}
+
+		return _jsEscapedSpecialChars;
+	}
+
 	protected String getSpecialChars() {
 		if (_specialChars == null) {
 			String specialChars = PropsUtil.get(
@@ -72,6 +83,7 @@ public class DefaultScreenNameValidator implements ScreenNameValidator {
 		return !screenName.matches("[A-Za-z0-9" + getSpecialChars() + "]+");
 	}
 
+	private String _jsEscapedSpecialChars;
 	private String _specialChars;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/DefaultScreenNameValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/DefaultScreenNameValidator.java
@@ -60,9 +60,7 @@ public class DefaultScreenNameValidator implements ScreenNameValidator {
 
 	protected String getJSEscapedSpecialChars() {
 		if (_jsEscapedSpecialChars == null) {
-			_jsEscapedSpecialChars = getSpecialChars();
-
-			_jsEscapedSpecialChars = HtmlUtil.escapeJS(_jsEscapedSpecialChars);
+			_jsEscapedSpecialChars = HtmlUtil.escapeJS(getSpecialChars());
 		}
 
 		return _jsEscapedSpecialChars;

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.1
+version 1.2.0


### PR DESCRIPTION
This is an update for [LPS-86711](https://issues.liferay.com/browse/LPS-86711).