### PR TITLE
LPS-86357 UserGroupServiceTest#testGetUserGroupsLikeName will fail if there are leftover UserGroups from another test case

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
@@ -85,32 +85,46 @@ public class UserGroupServiceTest {
 
 	@Test
 	public void testGetUserGroupsLikeName() throws Exception {
+		List<UserGroup> allUserGroups = new ArrayList<>();
+
+		allUserGroups.addAll(
+			UserGroupLocalServiceUtil.getUserGroups(
+				TestPropsValues.getCompanyId()));
+
+		List<UserGroup> likeNameUserGroups = new ArrayList<>();
+
 		String name = RandomTestUtil.randomString(10);
 
-		List<UserGroup> expectedUserGroups = new ArrayList<>();
-
 		for (int i = 0; i < 10; i++) {
-			UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+			UserGroup userGroup = addUserGroup();
 
 			userGroup.setName(name + i);
 
-			UserGroupLocalServiceUtil.updateUserGroup(userGroup);
+			userGroup = UserGroupLocalServiceUtil.updateUserGroup(userGroup);
 
-			expectedUserGroups.add(userGroup);
+			allUserGroups.add(userGroup);
+			likeNameUserGroups.add(userGroup);
 		}
 
-		_userGroups.addAll(expectedUserGroups);
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
+		allUserGroups.add(addUserGroup());
+		allUserGroups.add(addUserGroup());
+		allUserGroups.add(addUserGroup());
 
-		assertExpectedUserGroups(expectedUserGroups, name + "%");
+		assertExpectedUserGroups(likeNameUserGroups, name + "%");
 		assertExpectedUserGroups(
-			expectedUserGroups, StringUtil.toLowerCase(name) + "%");
+			likeNameUserGroups, StringUtil.toLowerCase(name) + "%");
 		assertExpectedUserGroups(
-			expectedUserGroups, StringUtil.toUpperCase(name) + "%");
-		assertExpectedUserGroups(_userGroups, null);
-		assertExpectedUserGroups(_userGroups, "");
+			likeNameUserGroups, StringUtil.toUpperCase(name) + "%");
+		assertExpectedUserGroups(allUserGroups, null);
+		assertExpectedUserGroups(allUserGroups, "");
+	}
+
+	protected UserGroup addUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroups.add(userGroup);
+
+		return userGroup;
 	}
 
 	protected void assertExpectedUserGroups(

--- a/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.service.UserGroupServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.StaleDataTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -90,6 +91,10 @@ public class UserGroupServiceTest {
 		allUserGroups.addAll(
 			UserGroupLocalServiceUtil.getUserGroups(
 				TestPropsValues.getCompanyId()));
+
+		StaleDataTestUtil.warn(
+			allUserGroups.isEmpty(),
+			"Expected no user groups, but found " + allUserGroups.size());
 
 		List<UserGroup> likeNameUserGroups = new ArrayList<>();
 

--- a/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
@@ -86,6 +86,8 @@ public class UserGroupServiceTest {
 
 	@Test
 	public void testGetUserGroupsLikeName() throws Exception {
+		addUserGroup();
+
 		List<UserGroup> allUserGroups = new ArrayList<>();
 
 		allUserGroups.addAll(

--- a/portal-test/src/com/liferay/portal/kernel/test/util/StaleDataTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/StaleDataTestUtil.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.test.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StackTraceUtil;
+
+/**
+ * @author Drew Brokke
+ */
+public class StaleDataTestUtil {
+
+	public static void warn(boolean condition, String warningMessage) {
+		if (!condition && _log.isWarnEnabled()) {
+			_log.warn(
+				"LRQA-44602 Stale data found: " +
+					StackTraceUtil.getStackTrace(
+						new Exception(warningMessage)));
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		StaleDataTestUtil.class);
+
+}


### PR DESCRIPTION
This is an update for [LPS-86357](https://issues.liferay.com/browse/LPS-86357).