### PR TITLE
LPS-85393

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -322,6 +322,7 @@ AUI.add(
 						var instance = this;
 
 						var sessionLength = instance.get('sessionLength');
+						var sessionState = instance.get('sessionState');
 						var warningTime = instance.get('warningTime');
 
 						var registered = instance._registered;
@@ -343,8 +344,6 @@ AUI.add(
 
 									if (instance._initTimestamp !== timestamp) {
 										instance.set('timestamp', timestamp);
-
-										var sessionState = instance.get('sessionState');
 
 										if (sessionState != 'active') {
 											instance.set('sessionState', 'active', SRC_EVENT_OBJ);
@@ -369,8 +368,6 @@ AUI.add(
 										extend = false;
 										hasExpired = true;
 									}
-
-									var sessionState = instance.get('sessionState');
 
 									if (hasExpired && sessionState != 'expired') {
 										if (extend) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -465,7 +465,7 @@ AUI.add(
 						var instance = this;
 
 						if (instance._banner) {
-							instance._banner.destroy();
+							instance._destroyBanner();
 						}
 					},
 

--- a/modules/apps/petra/petra-xml/src/main/java/com/liferay/petra/xml/XMLUtil.java
+++ b/modules/apps/petra/petra-xml/src/main/java/com/liferay/petra/xml/XMLUtil.java
@@ -56,6 +56,9 @@ public class XMLUtil {
 	}
 
 	public static String formatXML(String xml) {
+		xml = StringUtil.replace(xml, "]]><", "[$SPECIAL_CHARACTER$]");
+		xml = StringUtil.replace(xml, "]]>", "]]]]><![CDATA[>");
+		xml = StringUtil.replace(xml, "[$SPECIAL_CHARACTER$]", "]]><");
 
 		// This is only supposed to format your xml, however, it will also
 		// unwantingly change &#169; and other characters like it into their

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/controller/UADApplicationExportController.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/controller/UADApplicationExportController.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.zip.ZipReader;
@@ -155,7 +156,7 @@ public class UADApplicationExportController {
 		sb.append(StringPool.UNDERLINE);
 
 		if (user != null) {
-			sb.append(user.getFullName());
+			sb.append(HtmlUtil.escape(user.getFullName()));
 		}
 		else {
 			sb.append(userId);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-85393

Hey Drew,
This issue is kinda tricky in that I'm not 100% sure a solution should even be provided.  Basically, if a user has an exportable field which includes "]]>", we fail when parsing the user's XML-converted-model.  This is because CDATA uses "]]>" as a stop character, and there is no possible way to escape it.  So, I really only see two ways to resolving this issue:

1. Don't allow for certain characters in user fields (or at least prevent "]]>" from being used).
2. "Escape" the stop sequence by splitting it into two CDATA containers.  Here's how it works:

When exporting user data, the XML looks something like this:
`<column-value><![CDATA[FirstName]]> LastName]]></column-value>`
where the first name is "FirstName]]>" and the last name is "LastName".  When parsing the XML, you can see the reader wants to only use this chunk "<![CDATA[FirstName]]>", then parse for the next element.  Since there is no next element, the parser assumes the XML is broken, and throws an error.

My solution would be to simply include "]]" in the first CDATA container, and ">" in the second.  This splits the escape sequence, and allows for it to be used.  Further, there is no limit on how many CDATA containers can be used per element.  The XML would look something like this afterwards:
`<column-value><![CDATA[FirstName]]]]><![CDATA[> LastName]]></column-value>`
If your remove "]]><![CDATA[", you can see it ends up the correct value.

Lastly, if you do test my solution, please note you will receive a different error later on when validating the file name.  The character ">" is a blacklisted character, so the portal throws an exception when trying to create a file called "UAD_FirstName]]> LastName_com.liferay.message.boards.uad_201812132413.zip".  Breakpointing before false is returned in DLValidatorImpl.validateFileName or removing ">" from the character blacklist allows for the export to complete successfully.

Please let me know if you have any questions.  I know the outcome is strange, but this is the only way to "escape" CDATA containers.