### PR TITLE
LPS-88749, LPS-88742

### DIFF
--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
@@ -143,7 +143,7 @@ if (reminderAttempts == null) {
 						%>
 
 						<div class="alert alert-info">
-							<liferay-ui:message arguments="<%= HtmlUtil.escape(login) %>" key="a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question" translateArguments="<%= false %>" />
+							<liferay-ui:message arguments="<%= HtmlUtil.escape(login) %>" key="an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question" translateArguments="<%= false %>" />
 						</div>
 
 						<aui:input autoFocus="<%= true %>" label="<%= HtmlUtil.escape(LanguageUtil.get(request, user2.getReminderQueryQuestion())) %>" name="answer" type="text" />

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -73,7 +73,7 @@
 				<c:choose>
 					<c:when test='<%= SessionMessages.contains(request, "passwordSent") %>'>
 						<div class="alert alert-success">
-							<liferay-ui:message key="An-email-has-been-sent-to-the-provided-email-address" />
+							<liferay-ui:message key="an-email-has-been-sent-to-the-provided-email-address" />
 						</div>
 					</c:when>
 					<c:when test='<%= SessionMessages.contains(request, "userAdded") %>'>

--- a/modules/apps/login/login-web/src/main/resources/content/Language.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language.properties
@@ -1,4 +1,4 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Fast Sign In
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Sign In

--- a/modules/apps/login/login-web/src/main/resources/content/Language.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language.properties
@@ -1,5 +1,5 @@
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address.
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Fast Sign In
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Sign In
 thank-you-for-creating-an-account=Thank you for creating an account.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ar.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=سيتم إرسال كلمة مرور جديدة إلى {0} إذا استطعت الإجابة بشكل صحيح على السؤال التالي.
 an-email-has-been-sent-to-the-provided-email-address=وقد تم إرسال بريد إلكتروني إلى عنوان البريد الإلكتروني المتوفر. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=تسجيل دخول سريع
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=تسجيل الدخول
 thank-you-for-creating-an-account=نشكرك على إنشاء الحساب.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ar.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=سيتم إرسال كلمة مرور جديدة إلى {0} إذا استطعت الإجابة بشكل صحيح على السؤال التالي.
+an-email-has-been-sent-to-the-provided-email-address=وقد تم إرسال بريد إلكتروني إلى عنوان البريد الإلكتروني المتوفر. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=تسجيل دخول سريع
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=تسجيل الدخول
 thank-you-for-creating-an-account=نشكرك على إنشاء الحساب.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_bg.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова парола ще бъде изпратена на {0} ако отговорите успешно на следващия въпрос.
 an-email-has-been-sent-to-the-provided-email-address=Един имейл е изпратен на предоставения имейл адрес. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Бърз вход (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вход
 thank-you-for-creating-an-account=Благодаря ви за създаване на акаунт. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_bg.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова парола ще бъде изпратена на {0} ако отговорите успешно на следващия въпрос.
+an-email-has-been-sent-to-the-provided-email-address=Един имейл е изпратен на предоставения имейл адрес. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Бърз вход (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вход
 thank-you-for-creating-an-account=Благодаря ви за създаване на акаунт. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ca.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=S'ha enviat un correu electrònic a l'adreça proporcionada.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=S'enviarà una nova contrasenya a {0} si responeu correctament la pregunta següent.
+an-email-has-been-sent-to-the-provided-email-address=S'ha enviat un correu electrònic a l'adreça proporcionada.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Inici de sessió ràpid
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Inicia la sessió
 thank-you-for-creating-an-account=Gràcies per crear un compte.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ca.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=S'enviarà una nova contrasenya a {0} si responeu correctament la pregunta següent.
 an-email-has-been-sent-to-the-provided-email-address=S'ha enviat un correu electrònic a l'adreça proporcionada.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Inici de sessió ràpid
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Inicia la sessió
 thank-you-for-creating-an-account=Gràcies per crear un compte.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_cs.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Pokud správně zodpovíte následující otázku, na adresu {0} bude zasláno nové heslo.
+an-email-has-been-sent-to-the-provided-email-address=Zadané e-mailovou adresu byl odeslán e-mail. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Rychlé přihlášení
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Přihlášení
 thank-you-for-creating-an-account=Děkujeme za vytvoření účtu.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_cs.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Pokud správně zodpovíte následující otázku, na adresu {0} bude zasláno nové heslo.
 an-email-has-been-sent-to-the-provided-email-address=Zadané e-mailovou adresu byl odeslán e-mail. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Rychlé přihlášení
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Přihlášení
 thank-you-for-creating-an-account=Děkujeme za vytvoření účtu.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_da.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=En ny adgangskode sendes til {0} hvis du svarer korrekt på følgende spørgsmål.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hurtig log på
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Log ind
 thank-you-for-creating-an-account=Thank you for creating an account. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_da.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=En ny adgangskode sendes til {0} hvis du svarer korrekt på følgende spørgsmål.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hurtig log på
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Log ind
 thank-you-for-creating-an-account=Thank you for creating an account. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_de.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ein neues Kennwort wird an {0} geschickt werden, wenn Sie die folgende Frage richtig beantworten können.
 an-email-has-been-sent-to-the-provided-email-address=Eine E-Mail wurde an die angegebene E-Mail-Adresse gesendet.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Schnelle Anmeldung
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Anmeldung
 thank-you-for-creating-an-account=Vielen Dank, dass Sie ein Konto erstellt haben.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_de.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=Eine E-Mail wurde an die angegebene E-Mail-Adresse gesendet.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ein neues Kennwort wird an {0} geschickt werden, wenn Sie die folgende Frage richtig beantworten können.
+an-email-has-been-sent-to-the-provided-email-address=Eine E-Mail wurde an die angegebene E-Mail-Adresse gesendet.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Schnelle Anmeldung
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Anmeldung
 thank-you-for-creating-an-account=Vielen Dank, dass Sie ein Konto erstellt haben.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_el.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ένα νέο password θα σταλεί στο {0} αν απαντήσετε σωστά την επόμενη ερώτηση
 an-email-has-been-sent-to-the-provided-email-address=Ένα email έχει σταλεί στη διεύθυνση email που παρέχεται. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Γρήγορη είσοδος
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Είσοδος
 thank-you-for-creating-an-account=Ευχαριστούμε που δημιουργήσατε λογαριασμό στο site μας.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_el.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ένα νέο password θα σταλεί στο {0} αν απαντήσετε σωστά την επόμενη ερώτηση
+an-email-has-been-sent-to-the-provided-email-address=Ένα email έχει σταλεί στη διεύθυνση email που παρέχεται. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Γρήγορη είσοδος
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Είσοδος
 thank-you-for-creating-an-account=Ευχαριστούμε που δημιουργήσατε λογαριασμό στο site μας.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_en.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Fast Sign In
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Sign In
 thank-you-for-creating-an-account=Thank you for creating an account.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_en.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Fast Sign In
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Sign In
 thank-you-for-creating-an-account=Thank you for creating an account.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_es.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Se enviará una nueva contraseña a {0} si puede responder correctamente a la siguiente pregunta.
+an-email-has-been-sent-to-the-provided-email-address=Se ha enviado un correo electrónico a la dirección de correo electrónico proporcionada. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acceso rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Login
 thank-you-for-creating-an-account=Gracias por crear una cuenta de usuario.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_es.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Se enviará una nueva contraseña a {0} si puede responder correctamente a la siguiente pregunta.
 an-email-has-been-sent-to-the-provided-email-address=Se ha enviado un correo electrónico a la dirección de correo electrónico proporcionada. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acceso rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Login
 thank-you-for-creating-an-account=Gracias por crear una cuenta de usuario.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_et.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Kasutajale {0} saadetakse uus parool juhul, kui vastad õigesti järgnevale küsimusele.
 an-email-has-been-sent-to-the-provided-email-address=Sisestatud e-posti aadressile on saadetud e-posti. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Kiire sisselogimine (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logi sisse
 thank-you-for-creating-an-account=Täname luua konto. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_et.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Kasutajale {0} saadetakse uus parool juhul, kui vastad õigesti järgnevale küsimusele.
+an-email-has-been-sent-to-the-provided-email-address=Sisestatud e-posti aadressile on saadetud e-posti. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Kiire sisselogimine (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logi sisse
 thank-you-for-creating-an-account=Täname luua konto. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_eu.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Hurrengo galdera zuzen erantzuteko gai baldin bazara pasahitz berri bat {0}-(r)i bidaliko zaio.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Izen emate azkarra
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Izena ematea
 thank-you-for-creating-an-account=Mila esker kontua sortzeagatik.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_eu.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Hurrengo galdera zuzen erantzuteko gai baldin bazara pasahitz berri bat {0}-(r)i bidaliko zaio.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Izen emate azkarra
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Izena ematea
 thank-you-for-creating-an-account=Mila esker kontua sortzeagatik.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fa.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=اگر به سوال زیر پاسخ دهید،‌ رمز عبور جدید به صورت {0} تنظیم می‌شود.
+an-email-has-been-sent-to-the-provided-email-address=یک ایمیل به آدرس ایمیل ارائه شده فرستاده شده است. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=ورود سریع
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ورود
 thank-you-for-creating-an-account=با تشکر از ایجاد حساب

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fa.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=اگر به سوال زیر پاسخ دهید،‌ رمز عبور جدید به صورت {0} تنظیم می‌شود.
 an-email-has-been-sent-to-the-provided-email-address=یک ایمیل به آدرس ایمیل ارائه شده فرستاده شده است. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=ورود سریع
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ورود
 thank-you-for-creating-an-account=با تشکر از ایجاد حساب

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fi.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uusi salasana lähetetään osoitteeseen {0}, jos vastaat seuraavaan kysymykseen oikein.
 an-email-has-been-sent-to-the-provided-email-address=Sähköposti on lähetetty annettuun sähköpostiosoitteeseen.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Pikakirjautuminen
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Kirjaudu sisään
 thank-you-for-creating-an-account=Kiitos tilin luonnista.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fi.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=Sähköposti on lähetetty annettuun sähköpostiosoitteeseen.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uusi salasana lähetetään osoitteeseen {0}, jos vastaat seuraavaan kysymykseen oikein.
+an-email-has-been-sent-to-the-provided-email-address=Sähköposti on lähetetty annettuun sähköpostiosoitteeseen.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Pikakirjautuminen
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Kirjaudu sisään
 thank-you-for-creating-an-account=Kiitos tilin luonnista.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fr.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=Un e-mail a été envoyé à l'adresse fournie.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Un nouveau mot de passe sera envoyé à {0} si vous répondez correctement à la question suivante.
+an-email-has-been-sent-to-the-provided-email-address=Un e-mail a été envoyé à l'adresse fournie.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Connexion rapide
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Authentification
 thank-you-for-creating-an-account=Merci d'avoir créé un compte.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fr.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Un nouveau mot de passe sera envoyé à {0} si vous répondez correctement à la question suivante.
 an-email-has-been-sent-to-the-provided-email-address=Un e-mail a été envoyé à l'adresse fournie.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Connexion rapide
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Authentification
 thank-you-for-creating-an-account=Merci d'avoir créé un compte.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_gl.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Unha nova contraseña vai ser enviada a {0} si podes responder correctamente á seguinte pregunta.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Identificación rápida
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Rexistro
 thank-you-for-creating-an-account=Grazas por crear unha conta.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_gl.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Unha nova contraseña vai ser enviada a {0} si podes responder correctamente á seguinte pregunta.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Identificación rápida
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Rexistro
 thank-you-for-creating-an-account=Grazas por crear unha conta.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=निम्नलिखित प्रश्न का सही जवाब देने पर एक नया पासवर्ड आपके इस पते (0) पर भेजा जाएगा.
 an-email-has-been-sent-to-the-provided-email-address=एक ईमेल प्रदान किए गए ईमेल पते पर भेजा गया है । (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=में तेजी से साइन इन करें (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=साइन इन करें
 thank-you-for-creating-an-account=कोई खाता बनाने के लिए धन्यवाद। (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=निम्नलिखित प्रश्न का सही जवाब देने पर एक नया पासवर्ड आपके इस पते (0) पर भेजा जाएगा.
+an-email-has-been-sent-to-the-provided-email-address=एक ईमेल प्रदान किए गए ईमेल पते पर भेजा गया है । (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=में तेजी से साइन इन करें (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=साइन इन करें
 thank-you-for-creating-an-account=कोई खाता बनाने के लिए धन्यवाद। (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hr.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nova lozinka bit će poslana na {0} ukoliko ispravno odgovorite na slijedeće pitanje.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Brza prijava
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prijava
 thank-you-for-creating-an-account=Hvala vam što ste za stvaranje računa.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hr.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nova lozinka bit će poslana na {0} ukoliko ispravno odgovorite na slijedeće pitanje.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Brza prijava
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prijava
 thank-you-for-creating-an-account=Hvala vam što ste za stvaranje računa.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hu.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=Egy e-mailt küldtünk a megadott e-mail címre.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Új jelszót kapsz({0}), ha helyesen válaszolsz a következő kérdésre.
+an-email-has-been-sent-to-the-provided-email-address=Egy e-mailt küldtünk a megadott e-mail címre.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Gyors bejelentkezés
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Bejelentkezés
 thank-you-for-creating-an-account=Köszönjük, hogy fiókot hozott létre.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hu.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Új jelszót kapsz({0}), ha helyesen válaszolsz a következő kérdésre.
 an-email-has-been-sent-to-the-provided-email-address=Egy e-mailt küldtünk a megadott e-mail címre.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Gyors bejelentkezés
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Bejelentkezés
 thank-you-for-creating-an-account=Köszönjük, hogy fiókot hozott létre.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_in.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Sebuah password baru akan dikirim ke {0} jika Anda benar dapat menjawab pertanyaan berikut.
+an-email-has-been-sent-to-the-provided-email-address=Email telah dikirim ke alamat email yang disediakan. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Sign In Instan
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Masuk
 thank-you-for-creating-an-account=Terimakasih untuk membuat akun.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_in.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Sebuah password baru akan dikirim ke {0} jika Anda benar dapat menjawab pertanyaan berikut.
 an-email-has-been-sent-to-the-provided-email-address=Email telah dikirim ke alamat email yang disediakan. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Sign In Instan
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Masuk
 thank-you-for-creating-an-account=Terimakasih untuk membuat akun.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_it.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Una nuova password verrà inviata a {0} se rispondi correttamente alla seguente domanda.
+an-email-has-been-sent-to-the-provided-email-address=Un'email è stata inviata all'indirizzo di posta elettronica fornito. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Accesso veloce
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Login
 thank-you-for-creating-an-account=Grazie per aver creato un profilo.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_it.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Una nuova password verrà inviata a {0} se rispondi correttamente alla seguente domanda.
 an-email-has-been-sent-to-the-provided-email-address=Un'email è stata inviata all'indirizzo di posta elettronica fornito. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Accesso veloce
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Login
 thank-you-for-creating-an-account=Grazie per aver creato un profilo.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_iw.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=סיסמא חדשה תישלח ל-{0} אם תענה נכונה על השאלה הבאה.
 an-email-has-been-sent-to-the-provided-email-address=נשלחה הודעת דואר אלקטרוני לכתובת הדוא"ל שסופקה.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=כניסה מהירה
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=התחבר
 thank-you-for-creating-an-account=תודה על יצירת חשבון.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_iw.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=נשלחה הודעת דואר אלקטרוני לכתובת הדוא"ל שסופקה.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=סיסמא חדשה תישלח ל-{0} אם תענה נכונה על השאלה הבאה.
+an-email-has-been-sent-to-the-provided-email-address=נשלחה הודעת דואר אלקטרוני לכתובת הדוא"ל שסופקה.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=כניסה מהירה
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=התחבר
 thank-you-for-creating-an-account=תודה על יצירת חשבון.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ja.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=以下の質問に正しく答えると、新規パスワードが {0} に送信されます。
 an-email-has-been-sent-to-the-provided-email-address=入力されたメールアドレスにメールを送信しました。
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=簡易サインイン
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ログイン
 thank-you-for-creating-an-account=アカウントを作成していただきありがとうございます。

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ja.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=入力されたメールアドレスにメールを送信しました。
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=以下の質問に正しく答えると、新規パスワードが {0} に送信されます。
+an-email-has-been-sent-to-the-provided-email-address=入力されたメールアドレスにメールを送信しました。
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=簡易サインイン
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ログイン
 thank-you-for-creating-an-account=アカウントを作成していただきありがとうございます。

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ko.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 an-email-has-been-sent-to-the-provided-email-address=제공 된 이메일 주소로 이메일을 보냈습니다. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=빠른 로그인 (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=안으로 서명하십시요
 thank-you-for-creating-an-account=계정을 만들기 위한 감사 합니다. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ko.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
+an-email-has-been-sent-to-the-provided-email-address=제공 된 이메일 주소로 이메일을 보냈습니다. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=빠른 로그인 (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=안으로 서명하십시요
 thank-you-for-creating-an-account=계정을 만들기 위한 감사 합니다. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_lo.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=ລະຫັດຜ່ານຈະຖືກສົ່ງໄປຍັງ {0} ຖ້າທ່ານຕອບຄຳຖາມຕໍ່ໄປນີ້ໄດ້ຖືກຕ້ອງ.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=ການເຂົ້າດວ່ນ
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ເຂົ້າສູ່
 thank-you-for-creating-an-account=ຂອບໃຈສຳລັບການສ້າງບັນຊີຂອງທ່ານ.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_lo.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=ລະຫັດຜ່ານຈະຖືກສົ່ງໄປຍັງ {0} ຖ້າທ່ານຕອບຄຳຖາມຕໍ່ໄປນີ້ໄດ້ຖືກຕ້ອງ.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=ການເຂົ້າດວ່ນ
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ເຂົ້າສູ່
 thank-you-for-creating-an-account=ຂອບໃຈສຳລັບການສ້າງບັນຊີຂອງທ່ານ.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_lt.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 an-email-has-been-sent-to-the-provided-email-address=Elektroniniu paštu buvo išsiųstas į nurodytą elektroninio pašto adresą. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Greitai prisijungti (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Įeiti į sistemą
 thank-you-for-creating-an-account=Ačiū, kad sukurti sąskaitą. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_lt.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
+an-email-has-been-sent-to-the-provided-email-address=Elektroniniu paštu buvo išsiųstas į nurodytą elektroninio pašto adresą. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Greitai prisijungti (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Įeiti į sistemą
 thank-you-for-creating-an-account=Ačiū, kad sukurti sąskaitą. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nb.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Et nytt passord vil bli sendt til {0} dersom du besvarer følgende spørsmål korrekt.
+an-email-has-been-sent-to-the-provided-email-address=En e-post er sendt til den angitte e-postadressen. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hurtiginnlogging
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logg inn
 thank-you-for-creating-an-account=Takk for at du opprettet en konto.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nb.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Et nytt passord vil bli sendt til {0} dersom du besvarer følgende spørsmål korrekt.
 an-email-has-been-sent-to-the-provided-email-address=En e-post er sendt til den angitte e-postadressen. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hurtiginnlogging
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logg inn
 thank-you-for-creating-an-account=Takk for at du opprettet en konto.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nl.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=Er werd zonet een e-mail verzonden naar het opgegeven e-mailadres.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Als u de volgende vraag juist beantwoordt, wordt er een nieuw wachtwoord verzonden naar {0}.
+an-email-has-been-sent-to-the-provided-email-address=Er werd zonet een e-mail verzonden naar het opgegeven e-mailadres.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snel aanmelden
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Aanmelden
 thank-you-for-creating-an-account=Dank voor het aanmaken van uw account.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nl.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Als u de volgende vraag juist beantwoordt, wordt er een nieuw wachtwoord verzonden naar {0}.
 an-email-has-been-sent-to-the-provided-email-address=Er werd zonet een e-mail verzonden naar het opgegeven e-mailadres.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snel aanmelden
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Aanmelden
 thank-you-for-creating-an-account=Dank voor het aanmaken van uw account.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Indien je een juist antwoord geeft op de volgende vraag zal een nieuw wachtwoord worden verzonden naar {0}.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snel inloggen
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Aanmelden
 thank-you-for-creating-an-account=Bedankt voor het aanmaken van een account.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Indien je een juist antwoord geeft op de volgende vraag zal een nieuw wachtwoord worden verzonden naar {0}.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snel inloggen
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Aanmelden
 thank-you-for-creating-an-account=Bedankt voor het aanmaken van een account.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pl.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nowe hasło zostanie wysłane do {0} jeśli poprawnie odpowiesz na następujące pytanie.
+an-email-has-been-sent-to-the-provided-email-address=Wiadomość e-mail została wysłana na podany adres e-mail. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Szybkie logowanie
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logowanie
 thank-you-for-creating-an-account=Dziękujemy za założenie konta.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pl.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nowe hasło zostanie wysłane do {0} jeśli poprawnie odpowiesz na następujące pytanie.
 an-email-has-been-sent-to-the-provided-email-address=Wiadomość e-mail została wysłana na podany adres e-mail. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Szybkie logowanie
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logowanie
 thank-you-for-creating-an-account=Dziękujemy za założenie konta.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=Um e-mail foi enviado para o endereço de e-mail fornecido.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uma nova senha será enviada para {0} se você poder responder corretamente a seguinte questão.
+an-email-has-been-sent-to-the-provided-email-address=Um e-mail foi enviado para o endereço de e-mail fornecido.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acesso Rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Autenticação
 thank-you-for-creating-an-account=Obrigado por criar uma conta.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uma nova senha será enviada para {0} se você poder responder corretamente a seguinte questão.
 an-email-has-been-sent-to-the-provided-email-address=Um e-mail foi enviado para o endereço de e-mail fornecido.
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acesso Rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Autenticação
 thank-you-for-creating-an-account=Obrigado por criar uma conta.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uma nova Palavra-chave será enviada para {0} se responder correctamente à seguinte questão.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acesso Rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Entrar
 thank-you-for-creating-an-account=Obrigado por criar uma conta.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uma nova Palavra-chave será enviada para {0} se responder correctamente à seguinte questão.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acesso Rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Entrar
 thank-you-for-creating-an-account=Obrigado por criar uma conta.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ro.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=O parolă nouă va fi trimisă la {0} dacă poți răspunde corect la
+an-email-has-been-sent-to-the-provided-email-address=Un e-mail a fost trimis la adresa de e-mail furnizată. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Autentificare rapidă
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Autentificare
 thank-you-for-creating-an-account=Vă mulţumesc pentru a crea un cont. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ro.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=O parolă nouă va fi trimisă la {0} dacă poți răspunde corect la
 an-email-has-been-sent-to-the-provided-email-address=Un e-mail a fost trimis la adresa de e-mail furnizată. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Autentificare rapidă
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Autentificare
 thank-you-for-creating-an-account=Vă mulţumesc pentru a crea un cont. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ru.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Будет выслан новый пароль по адресу {0}, если вы правильно ответите на следующий вопрос.
 an-email-has-been-sent-to-the-provided-email-address=Сообщение было отправлено на указанный электронный адрес. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Быстрый вход
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вход в систему
 thank-you-for-creating-an-account=Спасибо за создание учетной записи.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ru.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Будет выслан новый пароль по адресу {0}, если вы правильно ответите на следующий вопрос.
+an-email-has-been-sent-to-the-provided-email-address=Сообщение было отправлено на указанный электронный адрес. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Быстрый вход
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вход в систему
 thank-you-for-creating-an-account=Спасибо за создание учетной записи.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sk.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ak správne zodpoviete nasledovnú otázku, bude vám zaslané nové heslo na adresu {0}.
 an-email-has-been-sent-to-the-provided-email-address=Uvedené e-mailovú adresu bol odoslaný email. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Rýchle prihlásenie
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prihlásenie
 thank-you-for-creating-an-account=Ďakujeme za vytvorenie účtu.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sk.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ak správne zodpoviete nasledovnú otázku, bude vám zaslané nové heslo na adresu {0}.
+an-email-has-been-sent-to-the-provided-email-address=Uvedené e-mailovú adresu bol odoslaný email. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Rýchle prihlásenie
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prihlásenie
 thank-you-for-creating-an-account=Ďakujeme za vytvorenie účtu.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sl.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Novo geslo bo poslano na {0} če boste pravilno odgovorili na naslednje vprašanje.
+an-email-has-been-sent-to-the-provided-email-address=Email je bil poslan na navedeni e-poštni naslov. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hitra prijava (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Registracija
 thank-you-for-creating-an-account=Zahvaljujemo se vam za ustvarjanje računa. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sl.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Novo geslo bo poslano na {0} če boste pravilno odgovorili na naslednje vprašanje.
 an-email-has-been-sent-to-the-provided-email-address=Email je bil poslan na navedeni e-poštni naslov. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hitra prijava (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Registracija
 thank-you-for-creating-an-account=Zahvaljujemo se vam za ustvarjanje računa. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова лозинка ће бити послата на {0} ако исправно одговорите на следеће питање.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Брзо Пријављивање
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Пријавите се
 thank-you-for-creating-an-account=Хвала вам за креирање налога.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова лозинка ће бити послата на {0} ако исправно одговорите на следеће питање.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Брзо Пријављивање
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Пријавите се
 thank-you-for-creating-an-account=Хвала вам за креирање налога.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nova lozinka će biti poslata na {0} ako ispravno odgovorite na sledeće pitanje.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Brzo Prijavljivanje
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prijavite se
 thank-you-for-creating-an-account=Hvala vam za kreiranje naloga.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nova lozinka će biti poslata na {0} ako ispravno odgovorite na sledeće pitanje.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Brzo Prijavljivanje
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prijavite se
 thank-you-for-creating-an-account=Hvala vam za kreiranje naloga.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sv.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ett nytt lösenord kommer att skickas till {0} om följande fråga kan besvaras korrekt.
 an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snabbinloggning
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logga in
 thank-you-for-creating-an-account=Tack för att du har skapat ett konto.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sv.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ett nytt lösenord kommer att skickas till {0} om följande fråga kan besvaras korrekt.
+an-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snabbinloggning
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logga in
 thank-you-for-creating-an-account=Tack för att du har skapat ett konto.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_th.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
+an-email-has-been-sent-to-the-provided-email-address=ส่งอีเมล์ไปยังที่อยู่อีเมลที่ให้มา (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=เข้าสู่ระบบอย่างรวดเร็ว (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=เข้าสู่ระบบ (Automatic Translation)
 thank-you-for-creating-an-account=ขอบคุณสำหรับการสร้างบัญชี (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_th.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 an-email-has-been-sent-to-the-provided-email-address=ส่งอีเมล์ไปยังที่อยู่อีเมลที่ให้มา (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=เข้าสู่ระบบอย่างรวดเร็ว (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=เข้าสู่ระบบ (Automatic Translation)
 thank-you-for-creating-an-account=ขอบคุณสำหรับการสร้างบัญชี (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_tr.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Soruya doğru cevap verirseniz yeni şifre {0}'a gönderilecek.
 an-email-has-been-sent-to-the-provided-email-address=Bir e-posta sağlanan e-posta adresine gönderildi. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hızlı oturum açma (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Oturum Aç
 thank-you-for-creating-an-account=Bir hesap oluşturmak için teşekkür ederiz. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_tr.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Soruya doğru cevap verirseniz yeni şifre {0}'a gönderilecek.
+an-email-has-been-sent-to-the-provided-email-address=Bir e-posta sağlanan e-posta adresine gönderildi. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hızlı oturum açma (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Oturum Aç
 thank-you-for-creating-an-account=Bir hesap oluşturmak için teşekkür ederiz. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_uk.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова пароля буде вислана на адресу {0}, якщо ви дасте правильну відповідь на наступне запитання:
+an-email-has-been-sent-to-the-provided-email-address=Лист був відправлений за адресою електронної пошти передбачено. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Швидкий увійти (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вхід до системи
 thank-you-for-creating-an-account=Дякуємо вам за створення облікового запису. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_uk.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова пароля буде вислана на адресу {0}, якщо ви дасте правильну відповідь на наступне запитання:
 an-email-has-been-sent-to-the-provided-email-address=Лист був відправлений за адресою електронної пошти передбачено. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Швидкий увійти (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вхід до системи
 thank-you-for-creating-an-account=Дякуємо вам за створення облікового запису. (Automatic Translation)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_vi.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Một mật khẩu mới sẽ được gửi tới {0} nếu bạn trả lời đúng các câu hỏi sau.
+an-email-has-been-sent-to-the-provided-email-address=Email đã được gửi đến địa chỉ email được cung cấp. (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Đăng nhập nhanh
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Đăng nhập
 thank-you-for-creating-an-account=Cảm ơn bạn đã đăng ký tạo tài khoản.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_vi.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Một mật khẩu mới sẽ được gửi tới {0} nếu bạn trả lời đúng các câu hỏi sau.
 an-email-has-been-sent-to-the-provided-email-address=Email đã được gửi đến địa chỉ email được cung cấp. (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Đăng nhập nhanh
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Đăng nhập
 thank-you-for-creating-an-account=Cảm ơn bạn đã đăng ký tạo tài khoản.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=如果您可以正确回答以下问题，新密码将发送到{0}。
 an-email-has-been-sent-to-the-provided-email-address=已向提供的电子邮件地址发送一封电子邮件。
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=快速登录
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=登录
 thank-you-for-creating-an-account=感谢您创建账户。

--- a/modules/apps/login/login-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=已向提供的电子邮件地址发送一封电子邮件。
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=如果您可以正确回答以下问题，新密码将发送到{0}。
+an-email-has-been-sent-to-the-provided-email-address=已向提供的电子邮件地址发送一封电子邮件。
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=快速登录
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=登录
 thank-you-for-creating-an-account=感谢您创建账户。

--- a/modules/apps/login/login-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,5 +1,5 @@
-An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=如果您能正確解答下列問題，一個新密碼將會傳送到 {0}。
+an-email-has-been-sent-to-the-provided-email-address=已向提供的電子郵件地址發送了一封電子郵件。 (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=快速登入
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=登入
 thank-you-for-creating-an-account=謝謝您創建一個帳戶。

--- a/modules/apps/login/login-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,5 +1,5 @@
-a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=如果您能正確解答下列問題，一個新密碼將會傳送到 {0}。
 an-email-has-been-sent-to-the-provided-email-address=已向提供的電子郵件地址發送了一封電子郵件。 (Automatic Translation)
+an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=An email will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=快速登入
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=登入
 thank-you-for-creating-an-account=謝謝您創建一個帳戶。


### PR DESCRIPTION
From @nellyliupeng
CC @wanderlast 

> **Main LPS:** https://issues.liferay.com/browse/LPS-88742
> 
> This fix includes an update to language keys to modify an info message being shown to the user when he/she requests a password reset link. Currently, the UI message warns the user that a password will be sent to the email provided. However, in reality a password reset url can also be sent to the email instead (if the option to receive reset link is selected). This fix was made to clarify ambiguity.
> 
> Other reasons used as to why fix was made:
> To match logic that was committed in https://github.com/brianchandotcom/liferay-portal/pull/63712
> 
> **Additional task:** https://issues.liferay.com/browse/LPS-88749
> Created to SF LPS-85971, and to separate autogenerated translated keys to those made for LPS-88742.