### PR TITLE
LPS-89543 The order arrow shouldn't appear if we don't have order elements

### DIFF
--- a/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
@@ -46,6 +46,7 @@ sortingURL.setParameter("orderByType", orderByType.equals("asc") ? "desc" : "asc
 />
 
 <clay:management-toolbar
+	disabled="<%= !PropsValues.LIVE_USERS_ENABLED || !PropsValues.SESSION_TRACKER_MEMORY_ENABLED %>"
 	selectable="<%= false %>"
 	showSearch="<%= false %>"
 	sortingOrder="<%= orderByType %>"


### PR DESCRIPTION
Hey @drewbrokke ,

Expected result in the ticket is to hide the ordering option, but I think it's more visually consistent with other Users pages to leave it disabled.

Please review the code.

Thank you!