### PR TITLE
[TS] LPS-93568

### DIFF
--- a/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/ConfigurationSynchronousConfigurationListener.java
+++ b/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/ConfigurationSynchronousConfigurationListener.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.Message;
 
 import org.osgi.framework.Constants;
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationEvent;
 import org.osgi.service.cm.SynchronousConfigurationListener;
 import org.osgi.service.component.annotations.Component;
@@ -44,12 +43,6 @@ public class ConfigurationSynchronousConfigurationListener
 
 		message.setDestinationName(
 			ConfigurationClusterDestinationNames.CONFIGURATION);
-
-		String factoryPid = configurationEvent.getFactoryPid();
-
-		if (factoryPid != null) {
-			message.put(ConfigurationAdmin.SERVICE_FACTORYPID, factoryPid);
-		}
 
 		message.put(Constants.SERVICE_PID, configurationEvent.getPid());
 

--- a/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/messaging/ConfigurationMessageListener.java
+++ b/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/messaging/ConfigurationMessageListener.java
@@ -51,18 +51,9 @@ public class ConfigurationMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		if (message.contains(ConfigurationAdmin.SERVICE_FACTORYPID)) {
-			reloadConfiguration(
-				message.getString(ConfigurationAdmin.SERVICE_FACTORYPID),
-				ConfigurationAdmin.SERVICE_FACTORYPID,
-				message.getInteger("configuration.event.type"));
-		}
-
-		if (message.contains(Constants.SERVICE_PID)) {
-			reloadConfiguration(
-				message.getString(Constants.SERVICE_PID), Constants.SERVICE_PID,
-				message.getInteger("configuration.event.type"));
-		}
+		reloadConfiguration(
+			message.getString(Constants.SERVICE_PID), Constants.SERVICE_PID,
+			message.getInteger("configuration.event.type"));
 	}
 
 	protected void reloadConfiguration(String pid, String filter, int type)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93568

Hey Drew,
I asked @jrao to create and test the following solution which has passed his manual testing.  My mentality for removing the factoryPID was because it's pretty clear we shouldn't delete every configuration under the factory if we are only targeting the one supplied from the servicePID, but I also don't think it's necessary to update them all in the same scenario either.

Assuming the factory is the configuration being targeted, it should be passed along as the servicePID and still work properly.  I believe the factoryPID code is from 2015, so it's probably not needed anymore (at least with the inclusion of the servicePID aspect).

Please let me know if I've missed anything important, or if there is anything else Jesse or I can provide.  Thanks!