### PR TITLE
[TS] LPS-95837

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -509,7 +509,22 @@ public class OrganizationLocalServiceImpl
 
 	@Override
 	public String[] getChildrenTypes(String type) {
-		return _organizationTypesSettings.getChildrenTypes(type);
+		String[] childrenTypes = _organizationTypesSettings.getChildrenTypes(
+			type);
+
+		if (childrenTypes.length > 0) {
+			List<String> list = new ArrayList<>();
+
+			for (String childrenType : childrenTypes) {
+				if (Validator.isNotNull(childrenType)) {
+					list.add(childrenType);
+				}
+			}
+
+			childrenTypes = list.toArray(new String[0]);
+		}
+
+		return childrenTypes;
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-95837

Hey Drew,
Since the children types are stored as a configuration, I don't think it's possible to "save" an empty string array rather than the blank value which currently happens.  There are also situations where a config file is used, and a blank string is used anyways.

Let me know if you have any questions, thanks!