### PR TITLE
LPS-98420

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/messaging/UserImportMessageListener.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/messaging/UserImportMessageListener.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import com.liferay.portal.security.ldap.exportimport.LDAPUserImporter;
 import com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration;
@@ -52,7 +53,8 @@ public class UserImportMessageListener extends BaseMessageListener {
 	@Modified
 	protected void activate() {
 		LDAPImportConfiguration ldapImportConfiguration =
-			_ldapImportConfigurationProvider.getConfiguration(0L);
+			_ldapImportConfigurationProvider.getConfiguration(
+				_portal.getDefaultCompanyId());
 
 		int interval = ldapImportConfiguration.importInterval();
 
@@ -141,6 +143,11 @@ public class UserImportMessageListener extends BaseMessageListener {
 	}
 
 	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		_portal = portal;
+	}
+
+	@Reference(unbind = "-")
 	protected void setSchedulerEngineHelper(
 		SchedulerEngineHelper schedulerEngineHelper) {
 
@@ -160,6 +167,7 @@ public class UserImportMessageListener extends BaseMessageListener {
 	)
 	private volatile LDAPUserImporter _ldapUserImporter;
 
+	private Portal _portal;
 	private SchedulerEngineHelper _schedulerEngineHelper;
 
 	@Reference


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-98420

Hey Drew,

I'm sending this fix to you since it seems most closely related to user importing over Core Infra or Security.  Let me explain the situation and possible solutions.

Currently, in 70x and up, the LDAP import interval doesn't really do anything.  This is because the trigger uses the interval set on the company with ID 0, thus it's always the default of "10".  So regardless of what a user sets the interval to, the message is sent every 10 minutes.  The only aspect which works if if the user sets the interval to a number divisible by 10, lets say 60.  In this case, even though the message is sent every 10 minutes, the interval is checked against the last import time, thus users are only imported on the 6th attempt, or after 60 minutes.

I add so much explanation to this PR because I'm not entirely sure what the correct solution should be.  Here are my ideas:
1. The solution in this PR.  Quite simply we just retrieve the import interval from the default company and use it.
Pros: simple, covers probably most all use cases
Cons: Portal or bundle must be restarted for the trigger to be reset with the new interval.  Doesn't take into account possible other instances with possibly varying intervals.

2. Modify the scheduler to run for each instance, based on it's given interval.
Pros: Every instance's interval is ran accurately
Cons: May be tricky to implement as the activate method needs to be greatly reworked (companyId needs to be sent in the message, but current scheduler for UserImportMessageListener class doesn't have a message var), doesn't account for newly added instances - portal or bundle needs a restart.

3. Set the scheduler interval to 1 minute; the interval set by the user will be used once the message is received
Pros: very simple, all instances' intervals are correctly used.
Cons: at least one DB call per minute, since we must retrieve all companyIds.  Also just a lot of messages going though.

4. Do nothing.  We say a granularity of 10 minutes is all we need to provide.
Pros: very simple (no solution besides some documentation maybe)
cons: portal isn't as robust.

Let me know what you think; I figured this would be easier than a PTR request, but I can create one if that would be better.  Thanks!