### PR TITLE
LPS-101973 Passes expected DOMNode to FormData constructor rather than A.Node

### DIFF
--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/user/edit_user_dialogs.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/user/edit_user_dialogs.jsp
@@ -122,7 +122,7 @@ if (extension) {
 				</c:otherwise>
 			</c:choose>
 
-			var formData = new FormData(form);
+			var formData = new FormData(form.getDOMNode());
 
 			Liferay.Util.fetch(uri, {
 				body: formData,


### PR DESCRIPTION
/cc @markocikos. Can you guys double-check, make sure we don't have other instances of this?