### PR TITLE
[TS] LPS-102295

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3137,7 +3137,7 @@
     #
     # Env: LIFERAY_SESSION_PERIOD_PHISHING_PERIOD_PROTECTED_PERIOD_ATTRIBUTES
     #
-    session.phishing.protected.attributes=CAS_LOGIN,HTTPS_INITIAL,LAST_PATH,OPEN_ID_CONNECT_SESSION
+    session.phishing.protected.attributes=CAS_LOGIN,HTTPS_INITIAL,LAST_PATH,OPEN_ID_CONNECT_SESSION,SETUP_WIZARD_PASSWORD_UPDATED
 
     #
     # Set this to true to test whether users have cookie support before allowing


### PR DESCRIPTION
Hello,

https://issues.liferay.com/browse/LPS-102295

See ticket for issue description.

The reason the issue occurs is because prior to the fix introduced in LPS-103122 (https://issues.liferay.com/browse/LPS-103122), our liferay-release-tools invalidated the session if license was not deployed before basic configuration was completed.

Because LPS-103122 now has been merged, we are able to introduce this fix by adding SETUP_WIZARD_PASSWORD_UPDATED as an attribute that needs to be carried over from the invalidated session when [renewSession](https://github.com/liferay/liferay-portal/blob/42b9105d120818f69e4e9c675ec6fd1ee8eda9a6/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java#L365-L406) is called after basic configuration is completed.

As a result, when [isValidatePassword](https://github.com/liferay/liferay-portal/blob/42b9105d120818f69e4e9c675ec6fd1ee8eda9a6/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java#L172-L187) is called for the initial password set-up, you will be able to re-use the default password as expected.

cc/ @holatuwol