### PR TITLE
LPS-103362 product-navigation-taglib - (PersonalMenu.es.js) removes unused attributes

### DIFF
--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -215,9 +215,7 @@ public class GetPersonalMenuItemsMVCResourceCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		JSONObject dividerJSONObject = JSONFactoryUtil.createJSONObject();
-
-		dividerJSONObject.put("type", "divider");
+		JSONObject dividerJSONObject = JSONUtil.put("type", "divider");
 
 		if (themeDisplay.isImpersonated()) {
 			JSONObject impersonationJSONObject = JSONUtil.put(
@@ -236,28 +234,30 @@ public class GetPersonalMenuItemsMVCResourceCommand
 			);
 
 			jsonArray.put(impersonationJSONObject);
-			jsonArray.put(dividerJSONObject);
 		}
 
-		for (int i = 0; i < groupedPersonalMenuEntries.size(); i++) {
+		for (List<PersonalMenuEntry> groupedPersonalMenuEntry :
+				groupedPersonalMenuEntries) {
+
 			JSONArray personalMenuEntriesJSONArray =
 				_getPersonalMenuEntriesJSONArray(
-					portletRequest, groupedPersonalMenuEntries.get(i));
+					portletRequest, groupedPersonalMenuEntry);
 
 			if (personalMenuEntriesJSONArray.length() == 0) {
 				continue;
 			}
 
-			JSONObject jsonObject = JSONUtil.put(
-				"items", personalMenuEntriesJSONArray);
-
-			jsonObject.put("type", "group");
-
-			jsonArray.put(jsonObject);
-
-			if (i < (groupedPersonalMenuEntries.size() - 1)) {
+			if (jsonArray.length() > 0) {
 				jsonArray.put(dividerJSONObject);
 			}
+
+			JSONObject jsonObject = JSONUtil.put(
+				"items", personalMenuEntriesJSONArray
+			).put(
+				"type", "group"
+			);
+
+			jsonArray.put(jsonObject);
 		}
 
 		if ((jsonArray.length() > 0) && !themeDisplay.isImpersonated()) {

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -215,6 +215,10 @@ public class GetPersonalMenuItemsMVCResourceCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		JSONObject dividerJSONObject = JSONFactoryUtil.createJSONObject();
+
+		dividerJSONObject.put("type", "divider");
+
 		if (themeDisplay.isImpersonated()) {
 			JSONObject impersonationJSONObject = JSONUtil.put(
 				"items",
@@ -228,12 +232,11 @@ public class GetPersonalMenuItemsMVCResourceCommand
 					user.getFullName(),
 					LanguageUtil.get(themeDisplay.getLocale(), "impersonated"))
 			).put(
-				"separator", true
-			).put(
 				"type", "group"
 			);
 
 			jsonArray.put(impersonationJSONObject);
+			jsonArray.put(dividerJSONObject);
 		}
 
 		for (int i = 0; i < groupedPersonalMenuEntries.size(); i++) {
@@ -248,13 +251,13 @@ public class GetPersonalMenuItemsMVCResourceCommand
 			JSONObject jsonObject = JSONUtil.put(
 				"items", personalMenuEntriesJSONArray);
 
-			if (i < (groupedPersonalMenuEntries.size() - 1)) {
-				jsonObject.put("separator", true);
-			}
-
 			jsonObject.put("type", "group");
 
 			jsonArray.put(jsonObject);
+
+			if (i < (groupedPersonalMenuEntries.size() - 1)) {
+				jsonArray.put(dividerJSONObject);
+			}
 		}
 
 		if ((jsonArray.length() > 0) && !themeDisplay.isImpersonated()) {

--- a/modules/apps/product-navigation/product-navigation-taglib/.babelrc
+++ b/modules/apps/product-navigation/product-navigation-taglib/.babelrc
@@ -1,0 +1,5 @@
+{
+	"presets": [
+		"@babel/preset-react"
+	]
+}

--- a/modules/apps/product-navigation/product-navigation-taglib/.eslintrc.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/.eslintrc.js
@@ -1,4 +1,3 @@
-<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -12,12 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
---%>
 
-<%@ include file="/init.jsp" %>
-
-<%@ page import="com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys" %><%@
-page import="com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuCategoryRegistry" %><%@
-page import="com.liferay.product.navigation.taglib.internal.servlet.ServletContextUtil" %>
-
-<%@ page import="java.util.LinkedHashMap" %>
+module.exports = {
+	extends: ['liferay/react']
+};

--- a/modules/apps/product-navigation/product-navigation-taglib/.npmbundlerrc
+++ b/modules/apps/product-navigation/product-navigation-taglib/.npmbundlerrc
@@ -1,5 +1,6 @@
 {
     "ignore": [
-        "**/*"
+        "**/config.js",
+        "**/control_menu/**/*"
     ]
 }

--- a/modules/apps/product-navigation/product-navigation-taglib/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-taglib/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 	compileOnly project(":apps:product-navigation:product-navigation-personal-menu-api")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/product-navigation/product-navigation-taglib/package.json
+++ b/modules/apps/product-navigation/product-navigation-taglib/package.json
@@ -1,4 +1,13 @@
 {
+	"dependencies": {
+		"@clayui/button": "3.0.0",
+		"@clayui/drop-down": "3.0.0",
+		"@clayui/icon": "3.0.0",
+		"@clayui/sticker": "3.0.0",
+		"frontend-js-web": "*",
+		"prop-types": "15.7.2",
+		"react": "16.9.0"
+	},
 	"name": "product-navigation-taglib",
 	"scripts": {
 		"build": "liferay-npm-scripts build",

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
@@ -27,6 +28,8 @@ page import="com.liferay.product.navigation.control.menu.ProductNavigationContro
 page import="com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuEntryRegistry" %><%@
 page import="com.liferay.taglib.servlet.PipingServletResponse" %>
 
-<%@ page import="java.util.List" %>
+<%@ page import="java.util.HashMap" %><%@
+page import="java.util.List" %><%@
+page import="java.util.Map" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -13,18 +13,16 @@
  */
 
 import ClayButton from '@clayui/button';
-import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClaySticker from '@clayui/sticker';
 import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {createRef, useState} from 'react';
-
-const preloadPromise = createRef();
+import React, {useState, useRef} from 'react';
 
 function PersonalMenu({itemsURL}) {
-	const [active, setActive] = useState(false);
 	const [items, setItems] = useState([]);
+	const preloadPromise = useRef();
 
 	function preloadItems() {
 		if (!preloadPromise.current) {
@@ -32,26 +30,16 @@ function PersonalMenu({itemsURL}) {
 				.then(response => response.json())
 				.then(items => setItems(items));
 		}
-
-		return preloadPromise.current;
-	}
-
-	function toggleActive(newVal) {
-		preloadItems().then(setActive(newVal));
 	}
 
 	return (
 		<ClayDropDownWithItems
-			active={active}
-			alignmentPosition={Align.BottomRight}
 			items={items}
-			onActiveChange={toggleActive}
 			trigger={
 				<ClayButton
 					displayType="unstyled"
 					onFocus={preloadItems}
 					onMouseOver={preloadItems}
-					symbol="user"
 				>
 					<ClaySticker
 						className="user-icon-color-4"

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import ClaySticker from '@clayui/sticker';
+import {fetch} from 'frontend-js-web';
+import PropTypes from 'prop-types';
+import React, {createRef, useState} from 'react';
+
+const preloadPromise = createRef();
+
+function PersonalMenu({itemsURL}) {
+	const [active, setActive] = useState(false);
+	const [items, setItems] = useState([]);
+
+	function preloadItems() {
+		if (!preloadPromise.current) {
+			preloadPromise.current = fetch(itemsURL)
+				.then(response => response.json())
+				.then(items => setItems(items));
+		}
+
+		return preloadPromise.current;
+	}
+
+	function toggleActive(newVal) {
+		preloadItems().then(setActive(newVal));
+	}
+
+	return (
+		<ClayDropDownWithItems
+			active={active}
+			alignmentPosition={Align.BottomRight}
+			items={items}
+			onActiveChange={toggleActive}
+			trigger={
+				<ClayButton
+					displayType="unstyled"
+					onFocus={preloadItems}
+					onMouseOver={preloadItems}
+					symbol="user"
+				>
+					<ClaySticker
+						className="user-icon-color-4"
+						shape="circle"
+						size="lg"
+					>
+						<ClayIcon symbol="user" />
+					</ClaySticker>
+				</ClayButton>
+			}
+		/>
+	);
+}
+
+PersonalMenu.propTypes = {
+	itemsURL: PropTypes.string
+};
+
+export default function(props) {
+	return <PersonalMenu {...props} />;
+}

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
@@ -45,98 +45,21 @@ String label = (String)request.getAttribute("liferay-product-navigation:personal
 	<button aria-expanded="true" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle" id="<%= namespace + "personal_menu_dropdown_toggle" %>" ref="triggerButton" type="button">
 		<%= label %>
 	</button>
+
+	<%
+	ResourceURL resourceURL = PortletURLFactoryUtil.create(request, PersonalMenuPortletKeys.PERSONAL_MENU, PortletRequest.RESOURCE_PHASE);
+
+	resourceURL.setParameter("currentURL", themeDisplay.getURLCurrent());
+	resourceURL.setParameter("portletId", themeDisplay.getPpid());
+	resourceURL.setResourceID("/get_personal_menu_items");
+
+	Map<String, Object> data = new HashMap<>();
+
+	data.put("itemsURL", resourceURL.toString());
+	%>
+
+	<react:component
+		data="<%= data %>"
+		module="personal_menu/js/PersonalMenu.es"
+	/>
 </div>
-
-<%
-ResourceURL resourceURL = PortletURLFactoryUtil.create(request, PersonalMenuPortletKeys.PERSONAL_MENU, PortletRequest.RESOURCE_PHASE);
-
-resourceURL.setParameter("currentURL", themeDisplay.getURLCurrent());
-resourceURL.setParameter("portletId", themeDisplay.getPpid());
-resourceURL.setResourceID("/get_personal_menu_items");
-%>
-
-<aui:script require="clay-dropdown/src/ClayDropdown as ClayDropdown,metal-dom/src/dom as dom, metal-position/src/Position">
-	var toggle = document.getElementById('<%= namespace + "personal_menu_dropdown_toggle" %>');
-
-	if (toggle) {
-		dom.once(
-			toggle,
-			'click',
-			function(event) {
-				Liferay.Util.fetch(
-					'<%= resourceURL.toString() %>',
-					{
-						method: 'GET'
-					}
-				).then(
-					function(response) {
-						return response.json();
-					}
-				).then(
-					function(personalMenuItems) {
-						var personalMenu = new ClayDropdown.default(
-							{
-								element: '#<%= namespace + "personal_menu_dropdown_toggle" %>',
-								events: {
-									'willAttach': function(event) {
-										if (<%= expanded %>) {
-											this.expanded = true;
-										}
-
-										var toggleButton = this.element.querySelector('button');
-
-										toggleButton.focus();
-
-										var dropdown = this;
-
-										this.refs.dropdown.refs.portal.on(
-											'menuExpanded',
-											function(event) {
-												var Position = metalPositionSrcPosition.default;
-
-												var menu = this.element;
-												var menuRegion = Position.getRegion(menu);
-
-												if (menuRegion.top < 0) {
-													var body = document.querySelector('body');
-													var bodyRegion = Position.getRegion(body);
-
-													menu.style.top = bodyRegion.top + 'px';
-												}
-											}
-										);
-
-										this.refs.dropdown.refs.portal.on(
-											'rendered',
-											function(event) {
-												if (dropdown.expanded) {
-													this.element.classList.add('dropdown-menu-personal-menu');
-													this.element.classList.remove('dropdown-menu-indicator-start');
-
-													this.emit('menuExpanded', event);
-												}
-											}
-										);
-									}
-								},
-								items: personalMenuItems,
-								itemsIconAlignment: 'right',
-								label: toggle.innerHTML,
-								showToggleIcon: false,
-								spritemap: '<%= themeDisplay.getPathThemeImages().concat("/clay/icons.svg") %>'
-							},
-							'#<%= namespace + "personal_menu_dropdown" %>'
-						);
-
-						Liferay.once(
-							'beforeNavigate',
-							function(event) {
-								personalMenu.refs.dropdown.refs.portal.detach();
-							}
-						);
-					}
-				);
-			}
-		);
-	}
-</aui:script>


### PR DESCRIPTION
@jbalsas these are some WIP changes I made. Please let me know where you'd like to pick this up and any way I can help.

### In this pull: 
- [x] - Added missing build dependencies
- [x]  - Fixed missing dividers
- [x] - Simplified the code in the JS component, but feel free to discard it all if you are planning to make your own changes anyway. (255d445bbcf2)

### Outstanding issues: 
- [ ] The personal menu icon "shifts" after the initial render.
- [ ] Along the same line, the initial "impersonation" icon with the smaller circle is replaced by the simple user icon after intial render
- [ ] The user icon is no longer centered
- [ ] The dropdown still has a scrollbar
- [ ] The dropdown is not aligned to the bottom left
- [ ] The styles found in modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp#L26 are not applied, I'm open to suggestions about how to apply unique styles like this to React components.