### PR TITLE
LPS-103703 Add email validation for Email Sender

### DIFF
--- a/modules/apps/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/internal/portlet/action/EditCompanyMVCActionCommand.java
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/internal/portlet/action/EditCompanyMVCActionCommand.java
@@ -271,6 +271,15 @@ public class EditCompanyMVCActionCommand extends BaseFormMVCActionCommand {
 		UnicodeProperties properties = PropertiesParamUtil.getProperties(
 			actionRequest, "settings--");
 
+		if (properties.containsKey("admin.email.from.address")) {
+			String newEmail = properties.getProperty(
+				"admin.email.from.address");
+
+			if (!Validator.isEmailAddress(newEmail)) {
+				throw new EmailAddressException();
+			}
+		}
+
 		String[] discardLegacyKeys = ParamUtil.getStringValues(
 			actionRequest, "discardLegacyKey");
 

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/email.notifications/email_sender.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/email.notifications/email_sender.jsp
@@ -28,7 +28,9 @@ String adminEmailFromAddress = PrefsPropsUtil.getString(company.getCompanyId(), 
 
 	<aui:input cssClass="lfr-input-text-container" label="name" name='<%= "settings--" + PropsKeys.ADMIN_EMAIL_FROM_NAME + "--" %>' type="text" value="<%= adminEmailFromName %>" />
 
-	<liferay-ui:error key="emailFromAddress" message="please-enter-a-valid-email-address" />
+	<liferay-ui:error exception="<%= EmailAddressException.class %>" message="please-enter-a-valid-email-address" />
 
-	<aui:input cssClass="lfr-input-text-container" label="address" name='<%= "settings--" + PropsKeys.ADMIN_EMAIL_FROM_ADDRESS + "--" %>' type="text" value="<%= adminEmailFromAddress %>" />
+	<aui:input cssClass="lfr-input-text-container" label="address" name='<%= "settings--" + PropsKeys.ADMIN_EMAIL_FROM_ADDRESS + "--" %>' type="text" value="<%= adminEmailFromAddress %>">
+		<aui:validator name="email" />
+	</aui:input>
 </aui:fieldset>


### PR DESCRIPTION
/cc @katienesterovich

Notes from Katie:
> https://issues.liferay.com/browse/LPS-103703
> 
> Added front-end and server email validation.
> 
> Front-End Validation
> ![image](https://user-images.githubusercontent.com/51712906/68246368-43fd3100-ffde-11e9-8ce0-7198f73f1e92.png)
> 
> Server validation (invalid email resets to previously set email)
> <img alt="Screen Shot 2019-11-05 at 3 16 22 PM" width="1337" src="https://user-images.githubusercontent.com/51712906/68246895-59268f80-ffdf-11e9-973a-0b9488c2cf0c.png">