### PR TITLE
LPS-100616 Remove broken icon link, change href

### DIFF
--- a/modules/apps/directory/directory-web/src/main/resources/META-INF/resources/user/instant_messenger.jsp
+++ b/modules/apps/directory/directory-web/src/main/resources/META-INF/resources/user/instant_messenger.jsp
@@ -41,8 +41,7 @@ String skypeSn = selContact.getSkypeSn();
 				<liferay-ui:message key="skype" />
 			</dt>
 			<dd>
-				<%= HtmlUtil.escape(skypeSn) %>
-				<a href="callto://<%= HtmlUtil.escapeAttribute(skypeSn) %>"><img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="call-this-user" />" class="instant-messenger-logo" src="http://mystatus.skype.com/smallicon/<%= HtmlUtil.escapeAttribute(skypeSn) %>" /></a>
+				<a href="skype:<%= HtmlUtil.escapeAttribute(skypeSn) %>?chat"><%= HtmlUtil.escape(skypeSn) %></a>
 			</dd>
 		</c:if>
 	</dl>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/instant_messenger.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/instant_messenger.jsp
@@ -32,7 +32,7 @@ Contact selContact = (Contact)request.getAttribute("user.selContact");
 			<aui:input label="skype" name="skypeSn" />
 
 			<c:if test="<%= Validator.isNotNull(selContact.getSkypeSn()) %>">
-				<a href="callto://<%= HtmlUtil.escapeAttribute(selContact.getSkypeSn()) %>"><img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="call-this-user" />" src="http://mystatus.skype.com/smallicon/<%= HtmlUtil.escapeAttribute(selContact.getSkypeSn()) %>" /></a>
+				<a href="skype:<%= HtmlUtil.escapeAttribute(selContact.getSkypeSn()) %>?call"><liferay-ui:message escapeAttribute="<%= true %>" key="call-this-user" /></a>
 			</c:if>
 		</div>
 	</c:when>


### PR DESCRIPTION
/cc @katienesterovich:

Notes from Katie:
> https://issues.liferay.com/browse/LPS-100616
> 
> Previous implementation relied on a discontinued `mystatus` link to return a Skype status-icon. There were two usages - in User Contacts (from LPS ticket) and in Portal Directory widget. There is currently no replacement for the Skype icon in https://issues.liferay.com/browse/LPS-95502 sheet, so I opted to remove it. Additionally, I changed the href syntax used to open Skype (same as used in Loop) since the previous implementation did not work.

