### PR TITLE
[TS] LPS-105757

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
@@ -183,13 +183,13 @@ public class SelectUsersDisplayContext {
 		}
 
 		int usersCount = UserLocalServiceUtil.searchCount(
-			themeDisplay.getCompanyId(), searchTerms.getKeywords(),
+			themeDisplay, searchTerms.getKeywords(),
 			searchTerms.getStatus(), userParams);
 
 		userSearch.setTotal(usersCount);
 
 		List<User> users = UserLocalServiceUtil.search(
-			themeDisplay.getCompanyId(), searchTerms.getKeywords(),
+			themeDisplay, searchTerms.getKeywords(),
 			searchTerms.getStatus(), userParams, userSearch.getStart(),
 			userSearch.getEnd(), userSearch.getOrderByComparator());
 

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
@@ -183,15 +183,15 @@ public class SelectUsersDisplayContext {
 		}
 
 		int usersCount = UserLocalServiceUtil.searchCount(
-			themeDisplay, searchTerms.getKeywords(),
-			searchTerms.getStatus(), userParams);
+			themeDisplay, searchTerms.getKeywords(), searchTerms.getStatus(),
+			userParams);
 
 		userSearch.setTotal(usersCount);
 
 		List<User> users = UserLocalServiceUtil.search(
-			themeDisplay, searchTerms.getKeywords(),
-			searchTerms.getStatus(), userParams, userSearch.getStart(),
-			userSearch.getEnd(), userSearch.getOrderByComparator());
+			themeDisplay, searchTerms.getKeywords(), searchTerms.getStatus(),
+			userParams, userSearch.getStart(), userSearch.getEnd(),
+			userSearch.getOrderByComparator());
 
 		userSearch.setResults(users);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -3045,6 +3045,36 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 	}
 
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  obc the comparator to order the users by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
 	@Override
 	public List<User> search(
 		ThemeDisplay themeDisplay, String keywords, int status,
@@ -3099,7 +3129,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 *         <code>null</code>)
 	 * @return the matching users
 	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 *
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
 	 */
+	@Deprecated
 	@Override
 	public Hits search(
 		long companyId, String keywords, int status,
@@ -3107,6 +3141,44 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		return search(
 			companyId, keywords, status, params, start, end, new Sort[] {sort});
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the indexer parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  sort the field and direction to sort by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public Hits search(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort) {
+
+		return search(
+			themeDisplay, keywords, status, params, start, end, new Sort[] {sort});
 	}
 
 	/**
@@ -3263,7 +3335,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 *         <code>null</code>)
 	 * @return the matching users
 	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 *
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, OrderByComparator)}
 	 */
+	@Deprecated
 	@Override
 	public List<User> search(
 		long companyId, String firstName, String middleName, String lastName,
@@ -3285,6 +3361,73 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			return UsersAdminUtil.getUsers(
 				search(
 					companyId, firstName, middleName, lastName, screenName,
+					emailAddress, status, params, andSearch, start, end,
+					getSorts(obc)));
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(ThemeDisplay, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  obc the comparator to order the users by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public List<User> search(
+		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, OrderByComparator<User> obc) {
+
+		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
+
+		if (!indexer.isIndexerEnabled() ||
+			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
+
+			return userFinder.findByC_FN_MN_LN_SN_EA_S(
+				themeDisplay.getCompanyId(), firstName, middleName, lastName, screenName,
+				emailAddress, status, params, andSearch, start, end, obc);
+		}
+
+		try {
+			return UsersAdminUtil.getUsers(
+				search(
+					themeDisplay, firstName, middleName, lastName, screenName,
 					emailAddress, status, params, andSearch, start, end,
 					getSorts(obc)));
 		}
@@ -3329,7 +3472,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 *         <code>null</code>)
 	 * @return the matching users
 	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 *
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
 	 */
+	@Deprecated
 	@Override
 	public Hits search(
 		long companyId, String firstName, String middleName, String lastName,
@@ -3343,6 +3490,61 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			new Sort[] {sort});
 	}
 
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the indexer parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  sort the field and direction to sort by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public Hits search(
+		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort sort) {
+
+		return search(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end,
+			new Sort[] {sort});
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Override
 	public Hits search(
 		long companyId, String firstName, String middleName, String lastName,
@@ -3356,6 +3558,29 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			SearchContext searchContext = buildSearchContext(
 				companyId, firstName, middleName, lastName, null, screenName,
+				emailAddress, null, null, null, null, null, status, params,
+				andSearch, start, end, sorts);
+
+			return indexer.search(searchContext);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	@Override
+	public Hits search(
+		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts) {
+
+		try {
+			Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+				User.class);
+
+			SearchContext searchContext = buildSearchContext(
+				themeDisplay, firstName, middleName, lastName, null, screenName,
 				emailAddress, null, null, null, null, null, status, params,
 				andSearch, start, end, sorts);
 
@@ -3445,6 +3670,19 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 	}
 
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
 	@Override
 	public int searchCount(
 		ThemeDisplay themeDisplay, String keywords, int status,
@@ -3527,7 +3765,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
 	 *         or the last name 'smith'&quot;.
 	 * @return the number of matching users
+	 *
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #searchCount(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean)}
 	 */
+	@Deprecated
 	@Override
 	public int searchCount(
 		long companyId, String firstName, String middleName, String lastName,
@@ -3553,6 +3795,62 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			SearchContext searchContext = buildSearchContext(
 				companyId, firstName, middleName, lastName, fullName,
+				screenName, emailAddress, null, null, null, null, null, status,
+				params, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+			return (int)indexer.searchCount(searchContext);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	@Override
+	public int searchCount(
+		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch) {
+
+		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
+
+		if (!indexer.isIndexerEnabled() ||
+			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
+
+			return userFinder.countByC_FN_MN_LN_SN_EA_S(
+				themeDisplay.getCompanyId(), firstName, middleName, lastName, screenName,
+				emailAddress, status, params, andSearch);
+		}
+
+		try {
+			FullNameGenerator fullNameGenerator =
+				FullNameGeneratorFactory.getInstance();
+
+			String fullName = fullNameGenerator.getFullName(
+				firstName, middleName, lastName);
+
+			SearchContext searchContext = buildSearchContext(
+				themeDisplay, firstName, middleName, lastName, fullName,
 				screenName, emailAddress, null, null, null, null, null, status,
 				params, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
@@ -3644,6 +3942,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			params, start, end, null);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 */
+	@Deprecated
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
 			long companyId, String keywords, int status,
@@ -3654,6 +3957,21 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			companyId, keywords, status, params, start, end, new Sort[] {sort});
 	}
 
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+		throws PortalException {
+
+		return searchUsers(
+			themeDisplay, keywords, status, params, start, end, new Sort[] {sort});
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
 			long companyId, String keywords, int status,
@@ -3705,6 +4023,60 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		Sort[] sorts)
+		throws PortalException {
+
+		String firstName = null;
+		String middleName = null;
+		String lastName = null;
+		String fullName = null;
+		String screenName = null;
+		String emailAddress = null;
+		String street = null;
+		String city = null;
+		String zip = null;
+		String region = null;
+		String country = null;
+		boolean andOperator = false;
+
+		if (Validator.isNotNull(keywords)) {
+			firstName = keywords;
+			middleName = keywords;
+			lastName = keywords;
+			fullName = keywords;
+			screenName = keywords;
+			emailAddress = keywords;
+			street = keywords;
+			city = keywords;
+			zip = keywords;
+			region = keywords;
+			country = keywords;
+		}
+		else {
+			andOperator = true;
+		}
+
+		if (params != null) {
+			params.put("keywords", keywords);
+		}
+
+		SearchContext searchContext = buildSearchContext(
+			themeDisplay, firstName, middleName, lastName, fullName, screenName,
+			emailAddress, street, city, zip, region, country, status, params,
+			andOperator, start, end, sorts);
+
+		return searchUsers(searchContext);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
+	 */
+	@Deprecated
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
 			long companyId, String firstName, String middleName,
 			String lastName, String screenName, String emailAddress, int status,
 			LinkedHashMap<String, Object> params, boolean andSearch, int start,
@@ -3719,6 +4091,25 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort sort)
+		throws PortalException {
+
+		return searchUsers(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end,
+			new Sort[] {sort});
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])} 
+	 */
+	@Deprecated
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
 			long companyId, String firstName, String middleName,
 			String lastName, String screenName, String emailAddress, int status,
 			LinkedHashMap<String, Object> params, boolean andSearch, int start,
@@ -3727,6 +4118,22 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		SearchContext searchContext = buildSearchContext(
 			companyId, firstName, middleName, lastName, null, screenName,
+			emailAddress, null, null, null, null, null, status, params,
+			andSearch, start, end, sorts);
+
+		return searchUsers(searchContext);
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts)
+		throws PortalException {
+
+		SearchContext searchContext = buildSearchContext(
+			themeDisplay, firstName, middleName, lastName, null, screenName,
 			emailAddress, null, null, null, null, null, status, params,
 			andSearch, start, end, sorts);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -3047,62 +3047,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	/**
 	 * Returns an ordered range of all the users who match the keywords and
-	 * status, without using the indexer. It is preferable to use the indexed
-	 * version {@link #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
-	 * instead of this method wherever possible for performance reasons.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end -
-	 * start</code> instances. <code>start</code> and <code>end</code> are not
-	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
-	 * refers to the first result in the set. Setting both <code>start</code>
-	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
-	 * result set.
-	 * </p>
-	 *
-	 * @param  themeDisplay the theme display needed to build the SearchContext
-	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         user's first name, middle name, last name, screen name, or email
-	 *         address
-	 * @param  status the workflow status
-	 * @param  params the finder parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
-	 * @param  start the lower bound of the range of users
-	 * @param  end the upper bound of the range of users (not inclusive)
-	 * @param  obc the comparator to order the users by (optionally
-	 *         <code>null</code>)
-	 * @return the matching users
-	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
-	 */
-	@Override
-	public List<User> search(
-		ThemeDisplay themeDisplay, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end,
-		OrderByComparator<User> obc) {
-
-		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
-
-		if (!indexer.isIndexerEnabled() ||
-			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
-
-			return userFinder.findByKeywords(
-				themeDisplay.getCompanyId(), keywords, status, params, start, end, obc);
-		}
-
-		try {
-			return UsersAdminUtil.getUsers(
-				search(
-					themeDisplay, keywords, status, params, start, end,
-					getSorts(obc)));
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-	}
-
-	/**
-	 * Returns an ordered range of all the users who match the keywords and
 	 * status, using the indexer. It is preferable to use this method instead of
 	 * the non-indexed version whenever possible for performance reasons.
 	 *
@@ -3141,44 +3085,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		return search(
 			companyId, keywords, status, params, start, end, new Sort[] {sort});
-	}
-
-	/**
-	 * Returns an ordered range of all the users who match the keywords and
-	 * status, using the indexer. It is preferable to use this method instead of
-	 * the non-indexed version whenever possible for performance reasons.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end -
-	 * start</code> instances. <code>start</code> and <code>end</code> are not
-	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
-	 * refers to the first result in the set. Setting both <code>start</code>
-	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
-	 * result set.
-	 * </p>
-	 *
-	 * @param  themeDisplay the theme display needed to build the SearchContext
-	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         user's first name, middle name, last name, screen name, or email
-	 *         address
-	 * @param  status the workflow status
-	 * @param  params the indexer parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
-	 * @param  start the lower bound of the range of users
-	 * @param  end the upper bound of the range of users (not inclusive)
-	 * @param  sort the field and direction to sort by (optionally
-	 *         <code>null</code>)
-	 * @return the matching users
-	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
-	 */
-	@Override
-	public Hits search(
-		ThemeDisplay themeDisplay, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end, Sort sort) {
-
-		return search(
-			themeDisplay, keywords, status, params, start, end, new Sort[] {sort});
 	}
 
 	/**
@@ -3232,62 +3138,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			SearchContext searchContext = buildSearchContext(
 				companyId, firstName, middleName, lastName, fullName,
-				screenName, emailAddress, street, city, zip, region, country,
-				status, params, andOperator, start, end, sorts);
-
-			return indexer.search(searchContext);
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-	}
-
-	@Override
-	public Hits search(
-		ThemeDisplay themeDisplay, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end,
-		Sort[] sorts) {
-
-		String firstName = null;
-		String middleName = null;
-		String lastName = null;
-		String fullName = null;
-		String screenName = null;
-		String emailAddress = null;
-		String street = null;
-		String city = null;
-		String zip = null;
-		String region = null;
-		String country = null;
-		boolean andOperator = false;
-
-		if (Validator.isNotNull(keywords)) {
-			firstName = keywords;
-			middleName = keywords;
-			lastName = keywords;
-			fullName = keywords;
-			screenName = keywords;
-			emailAddress = keywords;
-			street = keywords;
-			city = keywords;
-			zip = keywords;
-			region = keywords;
-			country = keywords;
-		}
-		else {
-			andOperator = true;
-		}
-
-		if (params != null) {
-			params.put("keywords", keywords);
-		}
-
-		try {
-			Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
-				User.class);
-
-			SearchContext searchContext = buildSearchContext(
-				themeDisplay, firstName, middleName, lastName, fullName,
 				screenName, emailAddress, street, city, zip, region, country,
 				status, params, andOperator, start, end, sorts);
 
@@ -3372,73 +3222,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	/**
 	 * Returns an ordered range of all the users with the status, and whose
 	 * first name, middle name, last name, screen name, and email address match
-	 * the keywords specified for them, without using the indexer. It is
-	 * preferable to use the indexed version {@link #search(ThemeDisplay, String,
-	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
-	 * Sort)} instead of this method wherever possible for performance reasons.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end -
-	 * start</code> instances. <code>start</code> and <code>end</code> are not
-	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
-	 * refers to the first result in the set. Setting both <code>start</code>
-	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
-	 * result set.
-	 * </p>
-	 *
-	 * @param  themeDisplay the theme display needed to build the SearchContext
-	 * @param  firstName the first name keywords (space separated)
-	 * @param  middleName the middle name keywords
-	 * @param  lastName the last name keywords
-	 * @param  screenName the screen name keywords
-	 * @param  emailAddress the email address keywords
-	 * @param  status the workflow status
-	 * @param  params the finder parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
-	 * @param  andSearch whether every field must match its keywords, or just
-	 *         one field. For example, &quot;users with the first name 'bob' and
-	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
-	 *         or the last name 'smith'&quot;.
-	 * @param  start the lower bound of the range of users
-	 * @param  end the upper bound of the range of users (not inclusive)
-	 * @param  obc the comparator to order the users by (optionally
-	 *         <code>null</code>)
-	 * @return the matching users
-	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
-	 */
-	@Override
-	public List<User> search(
-		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
-		String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, OrderByComparator<User> obc) {
-
-		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
-
-		if (!indexer.isIndexerEnabled() ||
-			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
-
-			return userFinder.findByC_FN_MN_LN_SN_EA_S(
-				themeDisplay.getCompanyId(), firstName, middleName, lastName, screenName,
-				emailAddress, status, params, andSearch, start, end, obc);
-		}
-
-		try {
-			return UsersAdminUtil.getUsers(
-				search(
-					themeDisplay, firstName, middleName, lastName, screenName,
-					emailAddress, status, params, andSearch, start, end,
-					getSorts(obc)));
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-	}
-
-	/**
-	 * Returns an ordered range of all the users with the status, and whose
-	 * first name, middle name, last name, screen name, and email address match
 	 * the keywords specified for them, using the indexer. It is preferable to
 	 * use this method instead of the non-indexed version whenever possible for
 	 * performance reasons.
@@ -3491,6 +3274,254 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
+	@Override
+	public Hits search(
+		long companyId, String firstName, String middleName, String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts) {
+
+		try {
+			Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+				User.class);
+
+			SearchContext searchContext = buildSearchContext(
+				companyId, firstName, middleName, lastName, null, screenName,
+				emailAddress, null, null, null, null, null, status, params,
+				andSearch, start, end, sorts);
+
+			return indexer.search(searchContext);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  obc the comparator to order the users by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public List<User> search(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		OrderByComparator<User> obc) {
+
+		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
+
+		if (!indexer.isIndexerEnabled() ||
+			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
+
+			return userFinder.findByKeywords(
+				themeDisplay.getCompanyId(), keywords, status, params, start,
+				end, obc);
+		}
+
+		try {
+			return UsersAdminUtil.getUsers(
+				search(
+					themeDisplay, keywords, status, params, start, end,
+					getSorts(obc)));
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the indexer parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  sort the field and direction to sort by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public Hits search(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort) {
+
+		return search(
+			themeDisplay, keywords, status, params, start, end,
+			new Sort[] {sort});
+	}
+
+	@Override
+	public Hits search(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		Sort[] sorts) {
+
+		String firstName = null;
+		String middleName = null;
+		String lastName = null;
+		String fullName = null;
+		String screenName = null;
+		String emailAddress = null;
+		String street = null;
+		String city = null;
+		String zip = null;
+		String region = null;
+		String country = null;
+		boolean andOperator = false;
+
+		if (Validator.isNotNull(keywords)) {
+			firstName = keywords;
+			middleName = keywords;
+			lastName = keywords;
+			fullName = keywords;
+			screenName = keywords;
+			emailAddress = keywords;
+			street = keywords;
+			city = keywords;
+			zip = keywords;
+			region = keywords;
+			country = keywords;
+		}
+		else {
+			andOperator = true;
+		}
+
+		if (params != null) {
+			params.put("keywords", keywords);
+		}
+
+		try {
+			Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+				User.class);
+
+			SearchContext searchContext = buildSearchContext(
+				themeDisplay, firstName, middleName, lastName, fullName,
+				screenName, emailAddress, street, city, zip, region, country,
+				status, params, andOperator, start, end, sorts);
+
+			return indexer.search(searchContext);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(ThemeDisplay, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  themeDisplay the theme display needed to build the SearchContext
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  obc the comparator to order the users by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public List<User> search(
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, OrderByComparator<User> obc) {
+
+		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
+
+		if (!indexer.isIndexerEnabled() ||
+			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
+
+			return userFinder.findByC_FN_MN_LN_SN_EA_S(
+				themeDisplay.getCompanyId(), firstName, middleName, lastName,
+				screenName, emailAddress, status, params, andSearch, start, end,
+				obc);
+		}
+
+		try {
+			return UsersAdminUtil.getUsers(
+				search(
+					themeDisplay, firstName, middleName, lastName, screenName,
+					emailAddress, status, params, andSearch, start, end,
+					getSorts(obc)));
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
 	 * Returns an ordered range of all the users with the status, and whose
 	 * first name, middle name, last name, screen name, and email address match
 	 * the keywords specified for them, using the indexer. It is preferable to
@@ -3529,8 +3560,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 */
 	@Override
 	public Hits search(
-		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
-		String screenName, String emailAddress, int status,
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort sort) {
 
@@ -3540,38 +3571,10 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			new Sort[] {sort});
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
-	 */
-	@Deprecated
 	@Override
 	public Hits search(
-		long companyId, String firstName, String middleName, String lastName,
-		String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort[] sorts) {
-
-		try {
-			Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
-				User.class);
-
-			SearchContext searchContext = buildSearchContext(
-				companyId, firstName, middleName, lastName, null, screenName,
-				emailAddress, null, null, null, null, null, status, params,
-				andSearch, start, end, sorts);
-
-			return indexer.search(searchContext);
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-	}
-
-	@Override
-	public Hits search(
-		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
-		String screenName, String emailAddress, int status,
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort[] sorts) {
 
@@ -3671,6 +3674,66 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 *
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #searchCount(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean)}
+	 */
+	@Deprecated
+	@Override
+	public int searchCount(
+		long companyId, String firstName, String middleName, String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch) {
+
+		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
+
+		if (!indexer.isIndexerEnabled() ||
+			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
+
+			return userFinder.countByC_FN_MN_LN_SN_EA_S(
+				companyId, firstName, middleName, lastName, screenName,
+				emailAddress, status, params, andSearch);
+		}
+
+		try {
+			FullNameGenerator fullNameGenerator =
+				FullNameGeneratorFactory.getInstance();
+
+			String fullName = fullNameGenerator.getFullName(
+				firstName, middleName, lastName);
+
+			SearchContext searchContext = buildSearchContext(
+				companyId, firstName, middleName, lastName, fullName,
+				screenName, emailAddress, null, null, null, null, null, status,
+				params, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+			return (int)indexer.searchCount(searchContext);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
 	 * Returns the number of users who match the keywords and status.
 	 *
 	 * @param  themeDisplay the theme display needed to build the SearchContext
@@ -3750,66 +3813,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 * name, last name, screen name, and email address match the keywords
 	 * specified for them.
 	 *
-	 * @param  companyId the primary key of the user's company
-	 * @param  firstName the first name keywords (space separated)
-	 * @param  middleName the middle name keywords
-	 * @param  lastName the last name keywords
-	 * @param  screenName the screen name keywords
-	 * @param  emailAddress the email address keywords
-	 * @param  status the workflow status
-	 * @param  params the finder parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
-	 * @param  andSearch whether every field must match its keywords, or just
-	 *         one field. For example, &quot;users with the first name 'bob' and
-	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
-	 *         or the last name 'smith'&quot;.
-	 * @return the number of matching users
-	 *
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #searchCount(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean)}
-	 */
-	@Deprecated
-	@Override
-	public int searchCount(
-		long companyId, String firstName, String middleName, String lastName,
-		String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch) {
-
-		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
-
-		if (!indexer.isIndexerEnabled() ||
-			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
-
-			return userFinder.countByC_FN_MN_LN_SN_EA_S(
-				companyId, firstName, middleName, lastName, screenName,
-				emailAddress, status, params, andSearch);
-		}
-
-		try {
-			FullNameGenerator fullNameGenerator =
-				FullNameGeneratorFactory.getInstance();
-
-			String fullName = fullNameGenerator.getFullName(
-				firstName, middleName, lastName);
-
-			SearchContext searchContext = buildSearchContext(
-				companyId, firstName, middleName, lastName, fullName,
-				screenName, emailAddress, null, null, null, null, null, status,
-				params, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-			return (int)indexer.searchCount(searchContext);
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-	}
-
-	/**
-	 * Returns the number of users with the status, and whose first name, middle
-	 * name, last name, screen name, and email address match the keywords
-	 * specified for them.
-	 *
 	 * @param  themeDisplay the theme display needed to build the SearchContext
 	 * @param  firstName the first name keywords (space separated)
 	 * @param  middleName the middle name keywords
@@ -3828,8 +3831,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 */
 	@Override
 	public int searchCount(
-		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
-		String screenName, String emailAddress, int status,
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch) {
 
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
@@ -3838,8 +3841,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
 
 			return userFinder.countByC_FN_MN_LN_SN_EA_S(
-				themeDisplay.getCompanyId(), firstName, middleName, lastName, screenName,
-				emailAddress, status, params, andSearch);
+				themeDisplay.getCompanyId(), firstName, middleName, lastName,
+				screenName, emailAddress, status, params, andSearch);
 		}
 
 		try {
@@ -3957,16 +3960,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			companyId, keywords, status, params, start, end, new Sort[] {sort});
 	}
 
-	@Override
-	public BaseModelSearchResult<User> searchUsers(
-		ThemeDisplay themeDisplay, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end, Sort sort)
-		throws PortalException {
-
-		return searchUsers(
-			themeDisplay, keywords, status, params, start, end, new Sort[] {sort});
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort[])}
@@ -4021,11 +4014,62 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		return searchUsers(searchContext);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
+	 */
+	@Deprecated
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-		ThemeDisplay themeDisplay, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end,
-		Sort[] sorts)
+			long companyId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort sort)
+		throws PortalException {
+
+		return searchUsers(
+			companyId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end,
+			new Sort[] {sort});
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+			long companyId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort[] sorts)
+		throws PortalException {
+
+		SearchContext searchContext = buildSearchContext(
+			companyId, firstName, middleName, lastName, null, screenName,
+			emailAddress, null, null, null, null, null, status, params,
+			andSearch, start, end, sorts);
+
+		return searchUsers(searchContext);
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+			ThemeDisplay themeDisplay, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+		throws PortalException {
+
+		return searchUsers(
+			themeDisplay, keywords, status, params, start, end,
+			new Sort[] {sort});
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+			ThemeDisplay themeDisplay, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end,
+			Sort[] sorts)
 		throws PortalException {
 
 		String firstName = null;
@@ -4070,31 +4114,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		return searchUsers(searchContext);
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
-	 */
-	@Deprecated
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-			long companyId, String firstName, String middleName,
+			ThemeDisplay themeDisplay, String firstName, String middleName,
 			String lastName, String screenName, String emailAddress, int status,
 			LinkedHashMap<String, Object> params, boolean andSearch, int start,
 			int end, Sort sort)
-		throws PortalException {
-
-		return searchUsers(
-			companyId, firstName, middleName, lastName, screenName,
-			emailAddress, status, params, andSearch, start, end,
-			new Sort[] {sort});
-	}
-
-	@Override
-	public BaseModelSearchResult<User> searchUsers(
-		ThemeDisplay themeDisplay, String firstName, String middleName,
-		String lastName, String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort sort)
 		throws PortalException {
 
 		return searchUsers(
@@ -4103,33 +4128,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			new Sort[] {sort});
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])} 
-	 */
-	@Deprecated
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-			long companyId, String firstName, String middleName,
+			ThemeDisplay themeDisplay, String firstName, String middleName,
 			String lastName, String screenName, String emailAddress, int status,
 			LinkedHashMap<String, Object> params, boolean andSearch, int start,
 			int end, Sort[] sorts)
-		throws PortalException {
-
-		SearchContext searchContext = buildSearchContext(
-			companyId, firstName, middleName, lastName, null, screenName,
-			emailAddress, null, null, null, null, null, status, params,
-			andSearch, start, end, sorts);
-
-		return searchUsers(searchContext);
-	}
-
-	@Override
-	public BaseModelSearchResult<User> searchUsers(
-		ThemeDisplay themeDisplay, String firstName, String middleName,
-		String lastName, String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort[] sorts)
 		throws PortalException {
 
 		SearchContext searchContext = buildSearchContext(
@@ -6330,9 +6334,10 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	protected SearchContext buildSearchContext(
-		ThemeDisplay themeDisplay, String firstName, String middleName, String lastName,
-		String fullName, String screenName, String emailAddress, String street,
-		String city, String zip, String region, String country, int status,
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String fullName, String screenName,
+		String emailAddress, String street, String city, String zip,
+		String region, String country, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort[] sorts) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -1594,7 +1595,10 @@ public interface UserLocalService
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, OrderByComparator)}
 	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<User> search(
 		long companyId, String keywords, int status,
@@ -1629,12 +1633,20 @@ public interface UserLocalService
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
 	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Hits search(
 		long companyId, String keywords, int status,
 		LinkedHashMap<String, Object> params, int start, int end, Sort sort);
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Hits search(
 		long companyId, String keywords, int status,
@@ -1677,7 +1689,10 @@ public interface UserLocalService
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, OrderByComparator)}
 	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<User> search(
 		long companyId, String firstName, String middleName, String lastName,
@@ -1721,7 +1736,10 @@ public interface UserLocalService
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
 	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Hits search(
 		long companyId, String firstName, String middleName, String lastName,
@@ -1729,10 +1747,186 @@ public interface UserLocalService
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort sort);
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Hits search(
 		long companyId, String firstName, String middleName, String lastName,
 		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts);
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<User> search(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		OrderByComparator<User> obc);
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort[] sorts);
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(ThemeDisplay, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<User> search(
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, OrderByComparator<User> obc);
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort sort);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort[] sorts);
 
@@ -1748,7 +1942,10 @@ public interface UserLocalService
 	 more information see {@link
 	 com.liferay.portal.kernel.service.persistence.UserFinder}.
 	 * @return the number matching users
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchCount(ThemeDisplay, String, int, LinkedHashMap)}
 	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int searchCount(
 		long companyId, String keywords, int status,
@@ -1774,11 +1971,59 @@ public interface UserLocalService
 	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
 	 or the last name 'smith'&quot;.
 	 * @return the number of matching users
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchCount(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean)}
 	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int searchCount(
 		long companyId, String firstName, String middleName, String lastName,
 		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch);
+
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		ThemeDisplay themeDisplay, String keywords, int status,
+		LinkedHashMap<String, Object> params);
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		ThemeDisplay themeDisplay, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -1806,12 +2051,22 @@ public interface UserLocalService
 			String keywords, int start, int end)
 		throws PortalException;
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BaseModelSearchResult<User> searchUsers(
 			long companyId, String keywords, int status,
 			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
 		throws PortalException;
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BaseModelSearchResult<User> searchUsers(
 			long companyId, String keywords, int status,
@@ -1819,6 +2074,11 @@ public interface UserLocalService
 			Sort[] sorts)
 		throws PortalException;
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BaseModelSearchResult<User> searchUsers(
 			long companyId, String firstName, String middleName,
@@ -1827,9 +2087,43 @@ public interface UserLocalService
 			int end, Sort sort)
 		throws PortalException;
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BaseModelSearchResult<User> searchUsers(
 			long companyId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort[] sorts)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<User> searchUsers(
+			ThemeDisplay themeDisplay, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<User> searchUsers(
+			ThemeDisplay themeDisplay, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end,
+			Sort[] sorts)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<User> searchUsers(
+			ThemeDisplay themeDisplay, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort sort)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<User> searchUsers(
+			ThemeDisplay themeDisplay, String firstName, String middleName,
 			String lastName, String screenName, String emailAddress, int status,
 			LinkedHashMap<String, Object> params, boolean andSearch, int start,
 			int end, Sort[] sorts)

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
@@ -2108,7 +2108,10 @@ public class UserLocalServiceUtil {
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, OrderByComparator)}
 	 */
+	@Deprecated
 	public static java.util.List<com.liferay.portal.kernel.model.User> search(
 		long companyId, String keywords, int status,
 		java.util.LinkedHashMap<String, Object> params, int start, int end,
@@ -2147,7 +2150,10 @@ public class UserLocalServiceUtil {
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
 	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.search.Hits search(
 		long companyId, String keywords, int status,
 		java.util.LinkedHashMap<String, Object> params, int start, int end,
@@ -2157,6 +2163,11 @@ public class UserLocalServiceUtil {
 			companyId, keywords, status, params, start, end, sort);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort[])}
+	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.search.Hits search(
 		long companyId, String keywords, int status,
 		java.util.LinkedHashMap<String, Object> params, int start, int end,
@@ -2203,7 +2214,10 @@ public class UserLocalServiceUtil {
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, OrderByComparator)}
 	 */
+	@Deprecated
 	public static java.util.List<com.liferay.portal.kernel.model.User> search(
 		long companyId, String firstName, String middleName, String lastName,
 		String screenName, String emailAddress, int status,
@@ -2253,7 +2267,10 @@ public class UserLocalServiceUtil {
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
 	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.search.Hits search(
 		long companyId, String firstName, String middleName, String lastName,
 		String screenName, String emailAddress, int status,
@@ -2265,6 +2282,11 @@ public class UserLocalServiceUtil {
 			emailAddress, status, params, andSearch, start, end, sort);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.search.Hits search(
 		long companyId, String firstName, String middleName, String lastName,
 		String screenName, String emailAddress, int status,
@@ -2273,6 +2295,209 @@ public class UserLocalServiceUtil {
 
 		return getService().search(
 			companyId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	public static java.util.List<com.liferay.portal.kernel.model.User> search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		String keywords, int status,
+		java.util.LinkedHashMap<String, Object> params, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return getService().search(
+			themeDisplay, keywords, status, params, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	public static com.liferay.portal.kernel.search.Hits search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		String keywords, int status,
+		java.util.LinkedHashMap<String, Object> params, int start, int end,
+		com.liferay.portal.kernel.search.Sort sort) {
+
+		return getService().search(
+			themeDisplay, keywords, status, params, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.Hits search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		String keywords, int status,
+		java.util.LinkedHashMap<String, Object> params, int start, int end,
+		com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return getService().search(
+			themeDisplay, keywords, status, params, start, end, sorts);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(ThemeDisplay, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	public static java.util.List<com.liferay.portal.kernel.model.User> search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		String firstName, String middleName, String lastName, String screenName,
+		String emailAddress, int status,
+		java.util.LinkedHashMap<String, Object> params, boolean andSearch,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return getService().search(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	public static com.liferay.portal.kernel.search.Hits search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		String firstName, String middleName, String lastName, String screenName,
+		String emailAddress, int status,
+		java.util.LinkedHashMap<String, Object> params, boolean andSearch,
+		int start, int end, com.liferay.portal.kernel.search.Sort sort) {
+
+		return getService().search(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.Hits search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		String firstName, String middleName, String lastName, String screenName,
+		String emailAddress, int status,
+		java.util.LinkedHashMap<String, Object> params, boolean andSearch,
+		int start, int end, com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return getService().search(
+			themeDisplay, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch, start, end, sorts);
 	}
 
@@ -2288,7 +2513,10 @@ public class UserLocalServiceUtil {
 	 more information see {@link
 	 com.liferay.portal.kernel.service.persistence.UserFinder}.
 	 * @return the number matching users
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchCount(ThemeDisplay, String, int, LinkedHashMap)}
 	 */
+	@Deprecated
 	public static int searchCount(
 		long companyId, String keywords, int status,
 		java.util.LinkedHashMap<String, Object> params) {
@@ -2316,7 +2544,10 @@ public class UserLocalServiceUtil {
 	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
 	 or the last name 'smith'&quot;.
 	 * @return the number of matching users
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchCount(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean)}
 	 */
+	@Deprecated
 	public static int searchCount(
 		long companyId, String firstName, String middleName, String lastName,
 		String screenName, String emailAddress, int status,
@@ -2324,6 +2555,59 @@ public class UserLocalServiceUtil {
 
 		return getService().searchCount(
 			companyId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch);
+	}
+
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
+	public static int searchCount(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		String keywords, int status,
+		java.util.LinkedHashMap<String, Object> params) {
+
+		return getService().searchCount(themeDisplay, keywords, status, params);
+	}
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	public static int searchCount(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		String firstName, String middleName, String lastName, String screenName,
+		String emailAddress, int status,
+		java.util.LinkedHashMap<String, Object> params, boolean andSearch) {
+
+		return getService().searchCount(
+			themeDisplay, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch);
 	}
 
@@ -2373,6 +2657,11 @@ public class UserLocalServiceUtil {
 			groupIds, userId, socialRelationTypes, keywords, start, end);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.portal.kernel.model.User> searchUsers(
 				long companyId, String keywords, int status,
@@ -2384,6 +2673,11 @@ public class UserLocalServiceUtil {
 			companyId, keywords, status, params, start, end, sort);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort[])}
+	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.portal.kernel.model.User> searchUsers(
 				long companyId, String keywords, int status,
@@ -2395,6 +2689,11 @@ public class UserLocalServiceUtil {
 			companyId, keywords, status, params, start, end, sorts);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
+	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.portal.kernel.model.User> searchUsers(
 				long companyId, String firstName, String middleName,
@@ -2409,6 +2708,11 @@ public class UserLocalServiceUtil {
 			emailAddress, status, params, andSearch, start, end, sort);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.portal.kernel.model.User> searchUsers(
 				long companyId, String firstName, String middleName,
@@ -2420,6 +2724,60 @@ public class UserLocalServiceUtil {
 
 		return getService().searchUsers(
 			companyId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+				String keywords, int status,
+				java.util.LinkedHashMap<String, Object> params, int start,
+				int end, com.liferay.portal.kernel.search.Sort sort)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchUsers(
+			themeDisplay, keywords, status, params, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+				String keywords, int status,
+				java.util.LinkedHashMap<String, Object> params, int start,
+				int end, com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchUsers(
+			themeDisplay, keywords, status, params, start, end, sorts);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+				String firstName, String middleName, String lastName,
+				String screenName, String emailAddress, int status,
+				java.util.LinkedHashMap<String, Object> params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort sort)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchUsers(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+				String firstName, String middleName, String lastName,
+				String screenName, String emailAddress, int status,
+				java.util.LinkedHashMap<String, Object> params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchUsers(
+			themeDisplay, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch, start, end, sorts);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
@@ -2270,7 +2270,10 @@ public class UserLocalServiceWrapper
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, OrderByComparator)}
 	 */
+	@Deprecated
 	@Override
 	public java.util.List<com.liferay.portal.kernel.model.User> search(
 		long companyId, java.lang.String keywords, int status,
@@ -2311,7 +2314,10 @@ public class UserLocalServiceWrapper
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
 	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.search.Hits search(
 		long companyId, java.lang.String keywords, int status,
@@ -2322,6 +2328,11 @@ public class UserLocalServiceWrapper
 			companyId, keywords, status, params, start, end, sort);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.search.Hits search(
 		long companyId, java.lang.String keywords, int status,
@@ -2369,7 +2380,10 @@ public class UserLocalServiceWrapper
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, OrderByComparator)}
 	 */
+	@Deprecated
 	@Override
 	public java.util.List<com.liferay.portal.kernel.model.User> search(
 		long companyId, java.lang.String firstName, java.lang.String middleName,
@@ -2421,7 +2435,10 @@ public class UserLocalServiceWrapper
 	 <code>null</code>)
 	 * @return the matching users
 	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
 	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.search.Hits search(
 		long companyId, java.lang.String firstName, java.lang.String middleName,
@@ -2436,6 +2453,11 @@ public class UserLocalServiceWrapper
 			emailAddress, status, params, andSearch, start, end, sort);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #search(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.search.Hits search(
 		long companyId, java.lang.String firstName, java.lang.String middleName,
@@ -2451,6 +2473,221 @@ public class UserLocalServiceWrapper
 	}
 
 	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.User> search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		java.lang.String keywords, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return _userLocalService.search(
+			themeDisplay, keywords, status, params, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		java.lang.String keywords, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end, com.liferay.portal.kernel.search.Sort sort) {
+
+		return _userLocalService.search(
+			themeDisplay, keywords, status, params, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		java.lang.String keywords, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end, com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return _userLocalService.search(
+			themeDisplay, keywords, status, params, start, end, sorts);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(ThemeDisplay, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.User> search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		java.lang.String firstName, java.lang.String middleName,
+		java.lang.String lastName, java.lang.String screenName,
+		java.lang.String emailAddress, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andSearch, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return _userLocalService.search(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		java.lang.String firstName, java.lang.String middleName,
+		java.lang.String lastName, java.lang.String screenName,
+		java.lang.String emailAddress, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andSearch, int start, int end,
+		com.liferay.portal.kernel.search.Sort sort) {
+
+		return _userLocalService.search(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		java.lang.String firstName, java.lang.String middleName,
+		java.lang.String lastName, java.lang.String screenName,
+		java.lang.String emailAddress, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andSearch, int start, int end,
+		com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return _userLocalService.search(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
+	}
+
+	/**
 	 * Returns the number of users who match the keywords and status.
 	 *
 	 * @param companyId the primary key of the user's company
@@ -2462,7 +2699,10 @@ public class UserLocalServiceWrapper
 	 more information see {@link
 	 com.liferay.portal.kernel.service.persistence.UserFinder}.
 	 * @return the number matching users
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchCount(ThemeDisplay, String, int, LinkedHashMap)}
 	 */
+	@Deprecated
 	@Override
 	public int searchCount(
 		long companyId, java.lang.String keywords, int status,
@@ -2492,7 +2732,10 @@ public class UserLocalServiceWrapper
 	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
 	 or the last name 'smith'&quot;.
 	 * @return the number of matching users
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchCount(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean)}
 	 */
+	@Deprecated
 	@Override
 	public int searchCount(
 		long companyId, java.lang.String firstName, java.lang.String middleName,
@@ -2503,6 +2746,64 @@ public class UserLocalServiceWrapper
 
 		return _userLocalService.searchCount(
 			companyId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch);
+	}
+
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
+	@Override
+	public int searchCount(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		java.lang.String keywords, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params) {
+
+		return _userLocalService.searchCount(
+			themeDisplay, keywords, status, params);
+	}
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param themeDisplay the theme display needed to build the SearchContext
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	@Override
+	public int searchCount(
+		com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+		java.lang.String firstName, java.lang.String middleName,
+		java.lang.String lastName, java.lang.String screenName,
+		java.lang.String emailAddress, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andSearch) {
+
+		return _userLocalService.searchCount(
+			themeDisplay, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch);
 	}
 
@@ -2553,6 +2854,11 @@ public class UserLocalServiceWrapper
 			groupIds, userId, socialRelationTypes, keywords, start, end);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort)}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.portal.kernel.model.User> searchUsers(
@@ -2566,6 +2872,11 @@ public class UserLocalServiceWrapper
 			companyId, keywords, status, params, start, end, sort);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, int, LinkedHashMap, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.portal.kernel.model.User> searchUsers(
@@ -2580,6 +2891,11 @@ public class UserLocalServiceWrapper
 			companyId, keywords, status, params, start, end, sorts);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort)}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.portal.kernel.model.User> searchUsers(
@@ -2598,6 +2914,11 @@ public class UserLocalServiceWrapper
 			emailAddress, status, params, andSearch, start, end, sort);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #searchUsers(ThemeDisplay, String, String, String, String, String, int, LinkedHashMap, boolean, int, int, Sort[])}
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.portal.kernel.model.User> searchUsers(
@@ -2613,6 +2934,71 @@ public class UserLocalServiceWrapper
 
 		return _userLocalService.searchUsers(
 			companyId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+				java.lang.String keywords, int status,
+				java.util.LinkedHashMap<java.lang.String, java.lang.Object>
+					params,
+				int start, int end, com.liferay.portal.kernel.search.Sort sort)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userLocalService.searchUsers(
+			themeDisplay, keywords, status, params, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+				java.lang.String keywords, int status,
+				java.util.LinkedHashMap<java.lang.String, java.lang.Object>
+					params,
+				int start, int end,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userLocalService.searchUsers(
+			themeDisplay, keywords, status, params, start, end, sorts);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+				java.lang.String firstName, java.lang.String middleName,
+				java.lang.String lastName, java.lang.String screenName,
+				java.lang.String emailAddress, int status,
+				java.util.LinkedHashMap<java.lang.String, java.lang.Object>
+					params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort sort)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userLocalService.searchUsers(
+			themeDisplay, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay,
+				java.lang.String firstName, java.lang.String middleName,
+				java.lang.String lastName, java.lang.String screenName,
+				java.lang.String emailAddress, int status,
+				java.util.LinkedHashMap<java.lang.String, java.lang.Object>
+					params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userLocalService.searchUsers(
+			themeDisplay, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch, start, end, sorts);
 	}
 


### PR DESCRIPTION
CC @wanderlast
From @jesseyeh-liferay:

## Problem :grimacing:

**[LPS-105757](https://issues.liferay.com/browse/LPS-105757)**

When a Site Administrator attempts to add users to a site via the "Assign Users to This Site" popup from a large pool of users (e.g., 25,000+ users), the popup experiences a big performance hit before the users are (incorrectly) displayed.

## Analysis :nerd_face:

#### Overview

The original implementation's logic flow is summarized as follows (key areas bolded):

1. `SelectUsersDisplayContext.getUserSearchContainer()`
    1. **`UserLocalServiceImpl.searchCount()`**
        1. **`buildSearchContext()`**
        1. `DefaultIndexer.search()`
            1. `IndexerSearcherImpl.searchCount()`
                1. `IndexerSearcherImpl._search()`
                    1. `DefaultSearchResultPermissionFilter.search()`
                        1. **`isGroupAdmin()`**
                        1. **`filterHits()`**
    1. **`UserLocalServiceImpl.search()`**
        1. **`buildSearchContext()`**
        1. `DefaultIndexer.search()`
            1. `IndexerSearcherImpl.search()`
                1. `IndexerSearcherImpl._search()`
                    1. `DefaultSearchResultPermissionFilter.search()`
                        1. **`isGroupAdmin()`**
                        1. **`SlidingWindowSearcher.search()`**

`isGroupAdmin()` checks for a `groupId` attribute on the `SearchContext`, which is created via `buildSearchContext()`. However, this attribute is non-existent, and as a result, the logic in the outermost `searchCount()` and `search()` calls incorrectly fall into routines that filter and iterate through the users (via a sliding window), respectively -- these two routines are responsible for the performance hit.

## Solution :tada:

We introduce the `groupId` attribute by deprecating relevant methods that only pass in a `long companyId` in favor of methods that pass in a `ThemeDisplay` instead. From the `ThemeDisplay`, we can retrieve both the company and group IDs, which we use to build the `SearchContext`, thus allowing the `isGroupAdmin()` check to pass for Site Administrators.