### PR TITLE
[TS] LPS-105757

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
@@ -183,15 +183,16 @@ public class SelectUsersDisplayContext {
 		}
 
 		int usersCount = UserLocalServiceUtil.searchCount(
-			themeDisplay.getCompanyId(), getGroupId(), searchTerms.getKeywords(),
-			searchTerms.getStatus(), userParams);
+			themeDisplay.getCompanyId(), getGroupId(),
+			searchTerms.getKeywords(), searchTerms.getStatus(), userParams);
 
 		userSearch.setTotal(usersCount);
 
 		List<User> users = UserLocalServiceUtil.search(
-			themeDisplay.getCompanyId(), getGroupId(), searchTerms.getKeywords(),
-			searchTerms.getStatus(), userParams, userSearch.getStart(),
-			userSearch.getEnd(), userSearch.getOrderByComparator());
+			themeDisplay.getCompanyId(), getGroupId(),
+			searchTerms.getKeywords(), searchTerms.getStatus(), userParams,
+			userSearch.getStart(), userSearch.getEnd(),
+			userSearch.getOrderByComparator());
 
 		userSearch.setResults(users);
 

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
@@ -183,13 +183,13 @@ public class SelectUsersDisplayContext {
 		}
 
 		int usersCount = UserLocalServiceUtil.searchCount(
-			themeDisplay.getCompanyId(), searchTerms.getKeywords(),
+			themeDisplay.getCompanyId(), getGroupId(), searchTerms.getKeywords(),
 			searchTerms.getStatus(), userParams);
 
 		userSearch.setTotal(usersCount);
 
 		List<User> users = UserLocalServiceUtil.search(
-			themeDisplay.getCompanyId(), searchTerms.getKeywords(),
+			themeDisplay.getCompanyId(), getGroupId(), searchTerms.getKeywords(),
 			searchTerms.getStatus(), userParams, userSearch.getStart(),
 			userSearch.getEnd(), userSearch.getOrderByComparator());
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -2986,44 +2986,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	/**
 	 * Returns an ordered range of all the users who match the keywords and
 	 * status, without using the indexer. It is preferable to use the indexed
-	 * version {@link #search(long, String, int, LinkedHashMap, int, int, Sort)}
-	 * instead of this method wherever possible for performance reasons.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end -
-	 * start</code> instances. <code>start</code> and <code>end</code> are not
-	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
-	 * refers to the first result in the set. Setting both <code>start</code>
-	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
-	 * result set.
-	 * </p>
-	 *
-	 * @param  companyId the primary key of the user's company
-	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         user's first name, middle name, last name, screen name, or email
-	 *         address
-	 * @param  status the workflow status
-	 * @param  params the finder parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
-	 * @param  start the lower bound of the range of users
-	 * @param  end the upper bound of the range of users (not inclusive)
-	 * @param  obc the comparator to order the users by (optionally
-	 *         <code>null</code>)
-	 * @return the matching users
-	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
-	 */
-	@Override
-	public List<User> search(
-		long companyId, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end,
-		OrderByComparator<User> obc) {
-		return search(companyId, 0, keywords, status, params, start, end, obc);
-	}
-
-	/**
-	 * Returns an ordered range of all the users who match the keywords and
-	 * status, without using the indexer. It is preferable to use the indexed
 	 * version {@link #search(long, long, String, int, LinkedHashMap, int, int, Sort)}
 	 * instead of this method wherever possible for performance reasons.
 	 *
@@ -3093,42 +3055,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 * </p>
 	 *
 	 * @param  companyId the primary key of the user's company
-	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         user's first name, middle name, last name, screen name, or email
-	 *         address
-	 * @param  status the workflow status
-	 * @param  params the indexer parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
-	 * @param  start the lower bound of the range of users
-	 * @param  end the upper bound of the range of users (not inclusive)
-	 * @param  sort the field and direction to sort by (optionally
-	 *         <code>null</code>)
-	 * @return the matching users
-	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
-	 */
-	@Override
-	public Hits search(
-		long companyId, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end, Sort sort) {
-		return search(companyId, 0, keywords, status, params, start, end, sort);
-	}
-
-	/**
-	 * Returns an ordered range of all the users who match the keywords and
-	 * status, using the indexer. It is preferable to use this method instead of
-	 * the non-indexed version whenever possible for performance reasons.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end -
-	 * start</code> instances. <code>start</code> and <code>end</code> are not
-	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
-	 * refers to the first result in the set. Setting both <code>start</code>
-	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
-	 * result set.
-	 * </p>
-	 *
-	 * @param  companyId the primary key of the user's company
 	 * @param  groupId the primary key of the user's group
 	 * @param  keywords the keywords (space separated), which may occur in the
 	 *         user's first name, middle name, last name, screen name, or email
@@ -3150,16 +3076,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		LinkedHashMap<String, Object> params, int start, int end, Sort sort) {
 
 		return search(
-			companyId, groupId, keywords, status, params, start, end, new Sort[] {sort});
-	}
-
-	@Override
-	public Hits search(
-		long companyId, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end,
-		Sort[] sorts) {
-		return search(
-			companyId, 0, keywords, status, params, start, end, sorts);
+			companyId, groupId, keywords, status, params, start, end,
+			new Sort[] {sort});
 	}
 
 	@Override
@@ -3222,6 +3140,234 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 * Returns an ordered range of all the users with the status, and whose
 	 * first name, middle name, last name, screen name, and email address match
 	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(long, long, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  groupId the primary key of the user's group
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  obc the comparator to order the users by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public List<User> search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, OrderByComparator<User> obc) {
+
+		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
+
+		if (!indexer.isIndexerEnabled() ||
+			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
+
+			return userFinder.findByC_FN_MN_LN_SN_EA_S(
+				companyId, firstName, middleName, lastName, screenName,
+				emailAddress, status, params, andSearch, start, end, obc);
+		}
+
+		try {
+			return UsersAdminUtil.getUsers(
+				search(
+					companyId, groupId, firstName, middleName, lastName,
+					screenName, emailAddress, status, params, andSearch, start,
+					end, getSorts(obc)));
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  groupId the primary key of the user's group
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the indexer parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  sort the field and direction to sort by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public Hits search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort sort) {
+
+		return search(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end,
+			new Sort[] {sort});
+	}
+
+	@Override
+	public Hits search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts) {
+
+		try {
+			Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+				User.class);
+
+			SearchContext searchContext = buildSearchContext(
+				companyId, groupId, firstName, middleName, lastName, null,
+				screenName, emailAddress, null, null, null, null, null, status,
+				params, andSearch, start, end, sorts);
+
+			return indexer.search(searchContext);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(long, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  obc the comparator to order the users by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public List<User> search(
+		long companyId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		OrderByComparator<User> obc) {
+
+		return search(companyId, 0, keywords, status, params, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the indexer parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  sort the field and direction to sort by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public Hits search(
+		long companyId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort) {
+
+		return search(companyId, 0, keywords, status, params, start, end, sort);
+	}
+
+	@Override
+	public Hits search(
+		long companyId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		Sort[] sorts) {
+
+		return search(
+			companyId, 0, keywords, status, params, start, end, sorts);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
 	 * preferable to use the indexed version {@link #search(long, String,
 	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
 	 * Sort)} instead of this method wherever possible for performance reasons.
@@ -3262,6 +3408,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, OrderByComparator<User> obc) {
+
 		return search(
 			companyId, 0, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch, start, end, obc);
@@ -3270,75 +3417,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	/**
 	 * Returns an ordered range of all the users with the status, and whose
 	 * first name, middle name, last name, screen name, and email address match
-	 * the keywords specified for them, without using the indexer. It is
-	 * preferable to use the indexed version {@link #search(long, long, String,
-	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
-	 * Sort)} instead of this method wherever possible for performance reasons.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end -
-	 * start</code> instances. <code>start</code> and <code>end</code> are not
-	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
-	 * refers to the first result in the set. Setting both <code>start</code>
-	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
-	 * result set.
-	 * </p>
-	 *
-	 * @param  companyId the primary key of the user's company
-	 * @param  groupId the primary key of the user's group
-	 * @param  firstName the first name keywords (space separated)
-	 * @param  middleName the middle name keywords
-	 * @param  lastName the last name keywords
-	 * @param  screenName the screen name keywords
-	 * @param  emailAddress the email address keywords
-	 * @param  status the workflow status
-	 * @param  params the finder parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
-	 * @param  andSearch whether every field must match its keywords, or just
-	 *         one field. For example, &quot;users with the first name 'bob' and
-	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
-	 *         or the last name 'smith'&quot;.
-	 * @param  start the lower bound of the range of users
-	 * @param  end the upper bound of the range of users (not inclusive)
-	 * @param  obc the comparator to order the users by (optionally
-	 *         <code>null</code>)
-	 * @return the matching users
-	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
-	 */
-	@Override
-	public List<User> search(
-		long companyId, long groupId, String firstName, String middleName,
-		String lastName,
-		String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, OrderByComparator<User> obc) {
-
-		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
-
-		if (!indexer.isIndexerEnabled() ||
-			!PropsValues.USERS_SEARCH_WITH_INDEX || isUseCustomSQL(params)) {
-
-			return userFinder.findByC_FN_MN_LN_SN_EA_S(
-				companyId, firstName, middleName, lastName, screenName,
-				emailAddress, status, params, andSearch, start, end, obc);
-		}
-
-		try {
-			return UsersAdminUtil.getUsers(
-				search(
-					companyId, groupId, firstName, middleName, lastName, screenName,
-					emailAddress, status, params, andSearch, start, end,
-					getSorts(obc)));
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-	}
-
-	/**
-	 * Returns an ordered range of all the users with the status, and whose
-	 * first name, middle name, last name, screen name, and email address match
 	 * the keywords specified for them, using the indexer. It is preferable to
 	 * use this method instead of the non-indexed version whenever possible for
 	 * performance reasons.
@@ -3379,116 +3457,22 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort sort) {
+
 		return search(
 			companyId, 0, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch, start, end, sort);
 	}
 
-	/**
-	 * Returns an ordered range of all the users with the status, and whose
-	 * first name, middle name, last name, screen name, and email address match
-	 * the keywords specified for them, using the indexer. It is preferable to
-	 * use this method instead of the non-indexed version whenever possible for
-	 * performance reasons.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end -
-	 * start</code> instances. <code>start</code> and <code>end</code> are not
-	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
-	 * refers to the first result in the set. Setting both <code>start</code>
-	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
-	 * result set.
-	 * </p>
-	 *
-	 * @param  companyId the primary key of the user's company
-	 * @param  groupId the primary key of the user's group
-	 * @param  firstName the first name keywords (space separated)
-	 * @param  middleName the middle name keywords
-	 * @param  lastName the last name keywords
-	 * @param  screenName the screen name keywords
-	 * @param  emailAddress the email address keywords
-	 * @param  status the workflow status
-	 * @param  params the indexer parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
-	 * @param  andSearch whether every field must match its keywords, or just
-	 *         one field. For example, &quot;users with the first name 'bob' and
-	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
-	 *         or the last name 'smith'&quot;.
-	 * @param  start the lower bound of the range of users
-	 * @param  end the upper bound of the range of users (not inclusive)
-	 * @param  sort the field and direction to sort by (optionally
-	 *         <code>null</code>)
-	 * @return the matching users
-	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
-	 */
-	@Override
-	public Hits search(
-		long companyId, long groupId, String firstName, String middleName,
-		String lastName,
-		String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort sort) {
-
-		return search(
-			companyId, groupId, firstName, middleName, lastName, screenName,
-			emailAddress, status, params, andSearch, start, end,
-			new Sort[] {sort});
-	}
-
 	@Override
 	public Hits search(
 		long companyId, String firstName, String middleName, String lastName,
 		String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort[] sorts) {
+
 		return search(
 			companyId, 0, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch, start, end, sorts);
-	}
-
-	@Override
-	public Hits search(
-		long companyId, long groupId, String firstName, String middleName,
-		String lastName,
-		String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort[] sorts) {
-
-		try {
-			Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
-				User.class);
-
-			SearchContext searchContext = buildSearchContext(
-				companyId, groupId, firstName, middleName, lastName, null, screenName,
-				emailAddress, null, null, null, null, null, status, params,
-				andSearch, start, end, sorts);
-
-			return indexer.search(searchContext);
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-	}
-
-	/**
-	 * Returns the number of users who match the keywords and status.
-	 *
-	 * @param  companyId the primary key of the user's company
-	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         user's first name, middle name, last name, screen name, or email
-	 *         address
-	 * @param  status the workflow status
-	 * @param  params the finder parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
-	 * @return the number matching users
-	 */
-	@Override
-	public int searchCount(
-		long companyId, String keywords, int status,
-		LinkedHashMap<String, Object> params) {
-		return searchCount(companyId, 0, keywords, status, params);
 	}
 
 	/**
@@ -3573,37 +3557,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 * specified for them.
 	 *
 	 * @param  companyId the primary key of the user's company
-	 * @param  firstName the first name keywords (space separated)
-	 * @param  middleName the middle name keywords
-	 * @param  lastName the last name keywords
-	 * @param  screenName the screen name keywords
-	 * @param  emailAddress the email address keywords
-	 * @param  status the workflow status
-	 * @param  params the finder parameters (optionally <code>null</code>). For
-	 *         more information see {@link
-	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
-	 * @param  andSearch whether every field must match its keywords, or just
-	 *         one field. For example, &quot;users with the first name 'bob' and
-	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
-	 *         or the last name 'smith'&quot;.
-	 * @return the number of matching users
-	 */
-	@Override
-	public int searchCount(
-		long companyId, String firstName, String middleName, String lastName,
-		String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch) {
-		return searchCount(
-			companyId, 0, firstName, middleName, lastName, screenName,
-			emailAddress, status, params, andSearch);
-	}
-
-	/**
-	 * Returns the number of users with the status, and whose first name, middle
-	 * name, last name, screen name, and email address match the keywords
-	 * specified for them.
-	 *
-	 * @param  companyId the primary key of the user's company
 	 * @param  groupId the primary key of the user's group
 	 * @param  firstName the first name keywords (space separated)
 	 * @param  middleName the middle name keywords
@@ -3623,8 +3576,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	@Override
 	public int searchCount(
 		long companyId, long groupId, String firstName, String middleName,
-		String lastName,
-		String screenName, String emailAddress, int status,
+		String lastName, String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch) {
 
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
@@ -3654,6 +3606,59 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		catch (Exception e) {
 			throw new SystemException(e);
 		}
+	}
+
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
+	@Override
+	public int searchCount(
+		long companyId, String keywords, int status,
+		LinkedHashMap<String, Object> params) {
+
+		return searchCount(companyId, 0, keywords, status, params);
+	}
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	@Override
+	public int searchCount(
+		long companyId, String firstName, String middleName, String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch) {
+
+		return searchCount(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch);
 	}
 
 	@Override
@@ -3739,38 +3744,20 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-		long companyId, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+			long companyId, long groupId, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
 		throws PortalException {
+
 		return searchUsers(
-			companyId, 0, keywords, status, params, start, end, sort);
+			companyId, groupId, keywords, status, params, start, end,
+			new Sort[] {sort});
 	}
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-		long companyId, long groupId, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end, Sort sort)
-		throws PortalException {
-
-		return searchUsers(
-			companyId, groupId, keywords, status, params, start, end, new Sort[] {sort});
-	}
-
-	@Override
-	public BaseModelSearchResult<User> searchUsers(
-		long companyId, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end,
-		Sort[] sorts)
-		throws PortalException {
-		return searchUsers(
-			companyId, 0, keywords, status, params, start, end, sorts);
-	}
-
-	@Override
-	public BaseModelSearchResult<User> searchUsers(
-		long companyId, long groupId, String keywords, int status,
-		LinkedHashMap<String, Object> params, int start, int end,
-		Sort[] sorts)
+			long companyId, long groupId, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end,
+			Sort[] sorts)
 		throws PortalException {
 
 		String firstName = null;
@@ -3808,31 +3795,19 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		SearchContext searchContext = buildSearchContext(
-			companyId, groupId, firstName, middleName, lastName, fullName, screenName,
-			emailAddress, street, city, zip, region, country, status, params,
-			andOperator, start, end, sorts);
+			companyId, groupId, firstName, middleName, lastName, fullName,
+			screenName, emailAddress, street, city, zip, region, country,
+			status, params, andOperator, start, end, sorts);
 
 		return searchUsers(searchContext);
 	}
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-		long companyId, String firstName, String middleName,
-		String lastName, String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort sort)
-		throws PortalException {
-		return searchUsers(
-			companyId, 0, firstName, middleName, lastName, screenName,
-			emailAddress, status, params, andSearch, start, end, sort);
-	}
-
-	@Override
-	public BaseModelSearchResult<User> searchUsers(
-		long companyId, long groupId, String firstName, String middleName,
-		String lastName, String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort sort)
+			long companyId, long groupId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort sort)
 		throws PortalException {
 
 		return searchUsers(
@@ -3843,30 +3818,65 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-		long companyId, String firstName, String middleName,
-		String lastName, String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort[] sorts)
+			long companyId, long groupId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort[] sorts)
 		throws PortalException {
-		return searchUsers(
-			companyId, 0, firstName, middleName, lastName, screenName,
-			emailAddress, status, params, andSearch, start, end, sorts);
+
+		SearchContext searchContext = buildSearchContext(
+			companyId, groupId, firstName, middleName, lastName, null,
+			screenName, emailAddress, null, null, null, null, null, status,
+			params, andSearch, start, end, sorts);
+
+		return searchUsers(searchContext);
 	}
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-		long companyId, long groupId, String firstName, String middleName,
-		String lastName, String screenName, String emailAddress, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort[] sorts)
+			long companyId, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
 		throws PortalException {
 
-		SearchContext searchContext = buildSearchContext(
-			companyId, groupId, firstName, middleName, lastName, null, screenName,
-			emailAddress, null, null, null, null, null, status, params,
-			andSearch, start, end, sorts);
+		return searchUsers(
+			companyId, 0, keywords, status, params, start, end, sort);
+	}
 
-		return searchUsers(searchContext);
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+			long companyId, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end,
+			Sort[] sorts)
+		throws PortalException {
+
+		return searchUsers(
+			companyId, 0, keywords, status, params, start, end, sorts);
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+			long companyId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort sort)
+		throws PortalException {
+
+		return searchUsers(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+			long companyId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort[] sorts)
+		throws PortalException {
+
+		return searchUsers(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
 	}
 
 	/**
@@ -5987,22 +5997,10 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	protected SearchContext buildSearchContext(
-		long companyId, String firstName, String middleName, String lastName,
-		String fullName, String screenName, String emailAddress, String street,
-		String city, String zip, String region, String country, int status,
-		LinkedHashMap<String, Object> params, boolean andSearch, int start,
-		int end, Sort[] sorts) {
-		return buildSearchContext(
-			companyId, 0, firstName, middleName, lastName, fullName, screenName,
-			emailAddress, street, city, zip, region, country, status, params,
-			andSearch, start, end, sorts);
-	}
-
-	protected SearchContext buildSearchContext(
 		long companyId, long groupId, String firstName, String middleName,
-		String lastName,
-		String fullName, String screenName, String emailAddress, String street,
-		String city, String zip, String region, String country, int status,
+		String lastName, String fullName, String screenName,
+		String emailAddress, String street, String city, String zip,
+		String region, String country, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort[] sorts) {
 
@@ -6052,6 +6050,19 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		queryConfig.setScoreEnabled(false);
 
 		return searchContext;
+	}
+
+	protected SearchContext buildSearchContext(
+		long companyId, String firstName, String middleName, String lastName,
+		String fullName, String screenName, String emailAddress, String street,
+		String city, String zip, String region, String country, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts) {
+
+		return buildSearchContext(
+			companyId, 0, firstName, middleName, lastName, fullName, screenName,
+			emailAddress, street, city, zip, region, country, status, params,
+			andSearch, start, end, sorts);
 	}
 
 	protected User doCheckLockout(User user, PasswordPolicy passwordPolicy)

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -3021,6 +3021,37 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		return search(companyId, 0, keywords, status, params, start, end, obc);
 	}
 
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(long, long, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  groupId the primary key of the user's group
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  obc the comparator to order the users by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
 	@Override
 	public List<User> search(
 		long companyId, long groupId, String keywords, int status,
@@ -3080,9 +3111,46 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	public Hits search(
 		long companyId, String keywords, int status,
 		LinkedHashMap<String, Object> params, int start, int end, Sort sort) {
+		return search(companyId, 0, keywords, status, params, start, end, sort);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  groupId the primary key of the user's group
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the indexer parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  sort the field and direction to sort by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public Hits search(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort) {
 
 		return search(
-			companyId, keywords, status, params, start, end, new Sort[] {sort});
+			companyId, groupId, keywords, status, params, start, end, new Sort[] {sort});
 	}
 
 	@Override
@@ -3194,6 +3262,57 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, OrderByComparator<User> obc) {
+		return search(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(long, long, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  groupId the primary key of the user's group
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  obc the comparator to order the users by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public List<User> search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, OrderByComparator<User> obc) {
 
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
 
@@ -3208,7 +3327,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		try {
 			return UsersAdminUtil.getUsers(
 				search(
-					companyId, firstName, middleName, lastName, screenName,
+					companyId, groupId, firstName, middleName, lastName, screenName,
 					emailAddress, status, params, andSearch, start, end,
 					getSorts(obc)));
 		}
@@ -3260,9 +3379,59 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort sort) {
+		return search(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  groupId the primary key of the user's group
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the indexer parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @param  start the lower bound of the range of users
+	 * @param  end the upper bound of the range of users (not inclusive)
+	 * @param  sort the field and direction to sort by (optionally
+	 *         <code>null</code>)
+	 * @return the matching users
+	 * @see    com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public Hits search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort sort) {
 
 		return search(
-			companyId, firstName, middleName, lastName, screenName,
+			companyId, groupId, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch, start, end,
 			new Sort[] {sort});
 	}
@@ -3273,13 +3442,25 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort[] sorts) {
+		return search(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
+	}
+
+	@Override
+	public Hits search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts) {
 
 		try {
 			Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 				User.class);
 
 			SearchContext searchContext = buildSearchContext(
-				companyId, firstName, middleName, lastName, null, screenName,
+				companyId, groupId, firstName, middleName, lastName, null, screenName,
 				emailAddress, null, null, null, null, null, status, params,
 				andSearch, start, end, sorts);
 
@@ -3310,6 +3491,20 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		return searchCount(companyId, 0, keywords, status, params);
 	}
 
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  groupId the primary key of the user's group
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user's first name, middle name, last name, screen name, or email
+	 *         address
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
 	@Override
 	public int searchCount(
 		long companyId, long groupId, String keywords, int status,
@@ -3398,6 +3593,39 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		long companyId, String firstName, String middleName, String lastName,
 		String screenName, String emailAddress, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch) {
+		return searchCount(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch);
+	}
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param  companyId the primary key of the user's company
+	 * @param  groupId the primary key of the user's group
+	 * @param  firstName the first name keywords (space separated)
+	 * @param  middleName the middle name keywords
+	 * @param  lastName the last name keywords
+	 * @param  screenName the screen name keywords
+	 * @param  emailAddress the email address keywords
+	 * @param  status the workflow status
+	 * @param  params the finder parameters (optionally <code>null</code>). For
+	 *         more information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param  andSearch whether every field must match its keywords, or just
+	 *         one field. For example, &quot;users with the first name 'bob' and
+	 *         last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 *         or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	@Override
+	public int searchCount(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName,
+		String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch) {
 
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
 
@@ -3417,7 +3645,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				firstName, middleName, lastName);
 
 			SearchContext searchContext = buildSearchContext(
-				companyId, firstName, middleName, lastName, fullName,
+				companyId, groupId, firstName, middleName, lastName, fullName,
 				screenName, emailAddress, null, null, null, null, null, status,
 				params, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
@@ -3511,19 +3739,38 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-			long companyId, String keywords, int status,
-			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+		long companyId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort)
 		throws PortalException {
-
 		return searchUsers(
-			companyId, keywords, status, params, start, end, new Sort[] {sort});
+			companyId, 0, keywords, status, params, start, end, sort);
 	}
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-			long companyId, String keywords, int status,
-			LinkedHashMap<String, Object> params, int start, int end,
-			Sort[] sorts)
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+		throws PortalException {
+
+		return searchUsers(
+			companyId, groupId, keywords, status, params, start, end, new Sort[] {sort});
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+		long companyId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		Sort[] sorts)
+		throws PortalException {
+		return searchUsers(
+			companyId, 0, keywords, status, params, start, end, sorts);
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		Sort[] sorts)
 		throws PortalException {
 
 		String firstName = null;
@@ -3561,7 +3808,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		SearchContext searchContext = buildSearchContext(
-			companyId, firstName, middleName, lastName, fullName, screenName,
+			companyId, groupId, firstName, middleName, lastName, fullName, screenName,
 			emailAddress, street, city, zip, region, country, status, params,
 			andOperator, start, end, sorts);
 
@@ -3570,28 +3817,52 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-			long companyId, String firstName, String middleName,
-			String lastName, String screenName, String emailAddress, int status,
-			LinkedHashMap<String, Object> params, boolean andSearch, int start,
-			int end, Sort sort)
+		long companyId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort sort)
+		throws PortalException {
+		return searchUsers(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort sort)
 		throws PortalException {
 
 		return searchUsers(
-			companyId, firstName, middleName, lastName, screenName,
+			companyId, groupId, firstName, middleName, lastName, screenName,
 			emailAddress, status, params, andSearch, start, end,
 			new Sort[] {sort});
 	}
 
 	@Override
 	public BaseModelSearchResult<User> searchUsers(
-			long companyId, String firstName, String middleName,
-			String lastName, String screenName, String emailAddress, int status,
-			LinkedHashMap<String, Object> params, boolean andSearch, int start,
-			int end, Sort[] sorts)
+		long companyId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts)
+		throws PortalException {
+		return searchUsers(
+			companyId, 0, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
+	}
+
+	@Override
+	public BaseModelSearchResult<User> searchUsers(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts)
 		throws PortalException {
 
 		SearchContext searchContext = buildSearchContext(
-			companyId, firstName, middleName, lastName, null, screenName,
+			companyId, groupId, firstName, middleName, lastName, null, screenName,
 			emailAddress, null, null, null, null, null, status, params,
 			andSearch, start, end, sorts);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
@@ -3017,6 +3018,14 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		long companyId, String keywords, int status,
 		LinkedHashMap<String, Object> params, int start, int end,
 		OrderByComparator<User> obc) {
+		return search(companyId, 0, keywords, status, params, start, end, obc);
+	}
+
+	@Override
+	public List<User> search(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		OrderByComparator<User> obc) {
 
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
 
@@ -3030,7 +3039,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		try {
 			return UsersAdminUtil.getUsers(
 				search(
-					companyId, keywords, status, params, start, end,
+					companyId, groupId, keywords, status, params, start, end,
 					getSorts(obc)));
 		}
 		catch (Exception e) {
@@ -3081,6 +3090,15 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		long companyId, String keywords, int status,
 		LinkedHashMap<String, Object> params, int start, int end,
 		Sort[] sorts) {
+		return search(
+			companyId, 0, keywords, status, params, start, end, sorts);
+	}
+
+	@Override
+	public Hits search(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		Sort[] sorts) {
 
 		String firstName = null;
 		String middleName = null;
@@ -3121,7 +3139,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				User.class);
 
 			SearchContext searchContext = buildSearchContext(
-				companyId, firstName, middleName, lastName, fullName,
+				companyId, groupId, firstName, middleName, lastName, fullName,
 				screenName, emailAddress, street, city, zip, region, country,
 				status, params, andOperator, start, end, sorts);
 
@@ -3289,6 +3307,13 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	public int searchCount(
 		long companyId, String keywords, int status,
 		LinkedHashMap<String, Object> params) {
+		return searchCount(companyId, 0, keywords, status, params);
+	}
+
+	@Override
+	public int searchCount(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params) {
 
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
 
@@ -3335,7 +3360,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			}
 
 			SearchContext searchContext = buildSearchContext(
-				companyId, firstName, middleName, lastName, fullName,
+				companyId, groupId, firstName, middleName, lastName, fullName,
 				screenName, emailAddress, street, city, zip, region, country,
 				status, params, andOperator, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, null);
@@ -5696,6 +5721,19 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		String city, String zip, String region, String country, int status,
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort[] sorts) {
+		return buildSearchContext(
+			companyId, 0, firstName, middleName, lastName, fullName, screenName,
+			emailAddress, street, city, zip, region, country, status, params,
+			andSearch, start, end, sorts);
+	}
+
+	protected SearchContext buildSearchContext(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName,
+		String fullName, String screenName, String emailAddress, String street,
+		String city, String zip, String region, String country, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts) {
 
 		SearchContext searchContext = new SearchContext();
 
@@ -5703,6 +5741,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		Map<String, Serializable> attributes = new HashMap<>();
 
+		attributes.put(Field.GROUP_ID, groupId);
 		attributes.put("city", city);
 		attributes.put("country", country);
 		attributes.put("emailAddress", emailAddress);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
@@ -1568,6 +1568,181 @@ public interface UserLocalService
 	/**
 	 * Returns an ordered range of all the users who match the keywords and
 	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(long, long, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<User> search(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end,
+		OrderByComparator<User> obc);
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort sort);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params, int start, int end, Sort[] sorts);
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(long, long, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<User> search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, OrderByComparator<User> obc);
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort sort);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts);
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
 	 * version {@link #search(long, String, int, LinkedHashMap, int, int, Sort)}
 	 * instead of this method wherever possible for performance reasons.
 	 *
@@ -1740,6 +1915,53 @@ public interface UserLocalService
 	 * Returns the number of users who match the keywords and status.
 	 *
 	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		long companyId, long groupId, String keywords, int status,
+		LinkedHashMap<String, Object> params);
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		LinkedHashMap<String, Object> params, boolean andSearch);
+
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param companyId the primary key of the user's company
 	 * @param keywords the keywords (space separated), which may occur in the
 	 user's first name, middle name, last name, screen name, or email
 	 address
@@ -1804,6 +2026,35 @@ public interface UserLocalService
 	public List<User> searchSocial(
 			long[] groupIds, long userId, int[] socialRelationTypes,
 			String keywords, int start, int end)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<User> searchUsers(
+			long companyId, long groupId, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<User> searchUsers(
+			long companyId, long groupId, String keywords, int status,
+			LinkedHashMap<String, Object> params, int start, int end,
+			Sort[] sorts)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<User> searchUsers(
+			long companyId, long groupId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort sort)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<User> searchUsers(
+			long companyId, long groupId, String firstName, String middleName,
+			String lastName, String screenName, String emailAddress, int status,
+			LinkedHashMap<String, Object> params, boolean andSearch, int start,
+			int end, Sort[] sorts)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
@@ -2082,6 +2082,207 @@ public class UserLocalServiceUtil {
 	/**
 	 * Returns an ordered range of all the users who match the keywords and
 	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(long, long, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	public static java.util.List<com.liferay.portal.kernel.model.User> search(
+		long companyId, long groupId, String keywords, int status,
+		java.util.LinkedHashMap<String, Object> params, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return getService().search(
+			companyId, groupId, keywords, status, params, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	public static com.liferay.portal.kernel.search.Hits search(
+		long companyId, long groupId, String keywords, int status,
+		java.util.LinkedHashMap<String, Object> params, int start, int end,
+		com.liferay.portal.kernel.search.Sort sort) {
+
+		return getService().search(
+			companyId, groupId, keywords, status, params, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.Hits search(
+		long companyId, long groupId, String keywords, int status,
+		java.util.LinkedHashMap<String, Object> params, int start, int end,
+		com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return getService().search(
+			companyId, groupId, keywords, status, params, start, end, sorts);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(long, long, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	public static java.util.List<com.liferay.portal.kernel.model.User> search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		java.util.LinkedHashMap<String, Object> params, boolean andSearch,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return getService().search(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	public static com.liferay.portal.kernel.search.Hits search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		java.util.LinkedHashMap<String, Object> params, boolean andSearch,
+		int start, int end, com.liferay.portal.kernel.search.Sort sort) {
+
+		return getService().search(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.Hits search(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		java.util.LinkedHashMap<String, Object> params, boolean andSearch,
+		int start, int end, com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return getService().search(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
 	 * version {@link #search(long, String, int, LinkedHashMap, int, int, Sort)}
 	 * instead of this method wherever possible for performance reasons.
 	 *
@@ -2280,6 +2481,60 @@ public class UserLocalServiceUtil {
 	 * Returns the number of users who match the keywords and status.
 	 *
 	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
+	public static int searchCount(
+		long companyId, long groupId, String keywords, int status,
+		java.util.LinkedHashMap<String, Object> params) {
+
+		return getService().searchCount(
+			companyId, groupId, keywords, status, params);
+	}
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	public static int searchCount(
+		long companyId, long groupId, String firstName, String middleName,
+		String lastName, String screenName, String emailAddress, int status,
+		java.util.LinkedHashMap<String, Object> params, boolean andSearch) {
+
+		return getService().searchCount(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch);
+	}
+
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param companyId the primary key of the user's company
 	 * @param keywords the keywords (space separated), which may occur in the
 	 user's first name, middle name, last name, screen name, or email
 	 address
@@ -2371,6 +2626,58 @@ public class UserLocalServiceUtil {
 
 		return getService().searchSocial(
 			groupIds, userId, socialRelationTypes, keywords, start, end);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				long companyId, long groupId, String keywords, int status,
+				java.util.LinkedHashMap<String, Object> params, int start,
+				int end, com.liferay.portal.kernel.search.Sort sort)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchUsers(
+			companyId, groupId, keywords, status, params, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				long companyId, long groupId, String keywords, int status,
+				java.util.LinkedHashMap<String, Object> params, int start,
+				int end, com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchUsers(
+			companyId, groupId, keywords, status, params, start, end, sorts);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				long companyId, long groupId, String firstName,
+				String middleName, String lastName, String screenName,
+				String emailAddress, int status,
+				java.util.LinkedHashMap<String, Object> params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort sort)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchUsers(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				long companyId, long groupId, String firstName,
+				String middleName, String lastName, String screenName,
+				String emailAddress, int status,
+				java.util.LinkedHashMap<String, Object> params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchUsers(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
 	}
 
 	public static com.liferay.portal.kernel.search.BaseModelSearchResult

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
@@ -2244,6 +2244,219 @@ public class UserLocalServiceWrapper
 	/**
 	 * Returns an ordered range of all the users who match the keywords and
 	 * status, without using the indexer. It is preferable to use the indexed
+	 * version {@link #search(long, long, String, int, LinkedHashMap, int, int, Sort)}
+	 * instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.User> search(
+		long companyId, long groupId, java.lang.String keywords, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return _userLocalService.search(
+			companyId, groupId, keywords, status, params, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, using the indexer. It is preferable to use this method instead of
+	 * the non-indexed version whenever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		long companyId, long groupId, java.lang.String keywords, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end, com.liferay.portal.kernel.search.Sort sort) {
+
+		return _userLocalService.search(
+			companyId, groupId, keywords, status, params, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		long companyId, long groupId, java.lang.String keywords, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end, com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return _userLocalService.search(
+			companyId, groupId, keywords, status, params, start, end, sorts);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, without using the indexer. It is
+	 * preferable to use the indexed version {@link #search(long, long, String,
+	 * String, String, String, String, int, LinkedHashMap, boolean, int, int,
+	 * Sort)} instead of this method wherever possible for performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param obc the comparator to order the users by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portal.kernel.service.persistence.UserFinder
+	 */
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.User> search(
+		long companyId, long groupId, java.lang.String firstName,
+		java.lang.String middleName, java.lang.String lastName,
+		java.lang.String screenName, java.lang.String emailAddress, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andSearch, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return _userLocalService.search(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the users with the status, and whose
+	 * first name, middle name, last name, screen name, and email address match
+	 * the keywords specified for them, using the indexer. It is preferable to
+	 * use this method instead of the non-indexed version whenever possible for
+	 * performance reasons.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the indexer parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portlet.usersadmin.util.UserIndexer}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @param start the lower bound of the range of users
+	 * @param end the upper bound of the range of users (not inclusive)
+	 * @param sort the field and direction to sort by (optionally
+	 <code>null</code>)
+	 * @return the matching users
+	 * @see com.liferay.portlet.usersadmin.util.UserIndexer
+	 */
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		long companyId, long groupId, java.lang.String firstName,
+		java.lang.String middleName, java.lang.String lastName,
+		java.lang.String screenName, java.lang.String emailAddress, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andSearch, int start, int end,
+		com.liferay.portal.kernel.search.Sort sort) {
+
+		return _userLocalService.search(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		long companyId, long groupId, java.lang.String firstName,
+		java.lang.String middleName, java.lang.String lastName,
+		java.lang.String screenName, java.lang.String emailAddress, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andSearch, int start, int end,
+		com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return _userLocalService.search(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
+	}
+
+	/**
+	 * Returns an ordered range of all the users who match the keywords and
+	 * status, without using the indexer. It is preferable to use the indexed
 	 * version {@link #search(long, String, int, LinkedHashMap, int, int, Sort)}
 	 * instead of this method wherever possible for performance reasons.
 	 *
@@ -2454,6 +2667,64 @@ public class UserLocalServiceWrapper
 	 * Returns the number of users who match the keywords and status.
 	 *
 	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user's first name, middle name, last name, screen name, or email
+	 address
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @return the number matching users
+	 */
+	@Override
+	public int searchCount(
+		long companyId, long groupId, java.lang.String keywords, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params) {
+
+		return _userLocalService.searchCount(
+			companyId, groupId, keywords, status, params);
+	}
+
+	/**
+	 * Returns the number of users with the status, and whose first name, middle
+	 * name, last name, screen name, and email address match the keywords
+	 * specified for them.
+	 *
+	 * @param companyId the primary key of the user's company
+	 * @param groupId the primary key of the user's group
+	 * @param firstName the first name keywords (space separated)
+	 * @param middleName the middle name keywords
+	 * @param lastName the last name keywords
+	 * @param screenName the screen name keywords
+	 * @param emailAddress the email address keywords
+	 * @param status the workflow status
+	 * @param params the finder parameters (optionally <code>null</code>). For
+	 more information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserFinder}.
+	 * @param andSearch whether every field must match its keywords, or just
+	 one field. For example, &quot;users with the first name 'bob' and
+	 last name 'smith'&quot; vs &quot;users with the first name 'bob'
+	 or the last name 'smith'&quot;.
+	 * @return the number of matching users
+	 */
+	@Override
+	public int searchCount(
+		long companyId, long groupId, java.lang.String firstName,
+		java.lang.String middleName, java.lang.String lastName,
+		java.lang.String screenName, java.lang.String emailAddress, int status,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andSearch) {
+
+		return _userLocalService.searchCount(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch);
+	}
+
+	/**
+	 * Returns the number of users who match the keywords and status.
+	 *
+	 * @param companyId the primary key of the user's company
 	 * @param keywords the keywords (space separated), which may occur in the
 	 user's first name, middle name, last name, screen name, or email
 	 address
@@ -2551,6 +2822,71 @@ public class UserLocalServiceWrapper
 
 		return _userLocalService.searchSocial(
 			groupIds, userId, socialRelationTypes, keywords, start, end);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				long companyId, long groupId, java.lang.String keywords,
+				int status,
+				java.util.LinkedHashMap<java.lang.String, java.lang.Object>
+					params,
+				int start, int end, com.liferay.portal.kernel.search.Sort sort)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userLocalService.searchUsers(
+			companyId, groupId, keywords, status, params, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				long companyId, long groupId, java.lang.String keywords,
+				int status,
+				java.util.LinkedHashMap<java.lang.String, java.lang.Object>
+					params,
+				int start, int end,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userLocalService.searchUsers(
+			companyId, groupId, keywords, status, params, start, end, sorts);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				long companyId, long groupId, java.lang.String firstName,
+				java.lang.String middleName, java.lang.String lastName,
+				java.lang.String screenName, java.lang.String emailAddress,
+				int status,
+				java.util.LinkedHashMap<java.lang.String, java.lang.Object>
+					params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort sort)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userLocalService.searchUsers(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.User> searchUsers(
+				long companyId, long groupId, java.lang.String firstName,
+				java.lang.String middleName, java.lang.String lastName,
+				java.lang.String screenName, java.lang.String emailAddress,
+				int status,
+				java.util.LinkedHashMap<java.lang.String, java.lang.Object>
+					params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userLocalService.searchUsers(
+			companyId, groupId, firstName, middleName, lastName, screenName,
+			emailAddress, status, params, andSearch, start, end, sorts);
 	}
 
 	@Override


### PR DESCRIPTION
From @jesseyeh-liferay

## Previous Pull Requests

https://github.com/wanderlast/liferay-portal/pull/35 > https://github.com/ChrisKian/liferay-portal/pull/163 > https://github.com/drewbrokke/liferay-portal/pull/939

## Changelog

* Use `companyId` and `groupId` instead of a single `ThemeDisplay` to be more explicit as described in https://github.com/drewbrokke/liferay-portal/pull/939#issuecomment-566805120
* Resolve merge conflict on `buildSearchContext()` introduced by d1cb96c

>## Problem :grimacing:
>
>**[LPS-105757](https://issues.liferay.com/browse/LPS-105757)**
>
>When a Site Administrator attempts to add users to a site via the "Assign Users to This Site" popup from a large pool of users (e.g., 25,000+ users), the popup experiences a big performance hit before the users are (incorrectly) displayed.
>
>## Analysis :nerd_face:
>
>#### Overview
>
>The original implementation's logic flow is summarized as follows (key areas bolded):
>
>1. `SelectUsersDisplayContext.getUserSearchContainer()`
>    1. **`UserLocalServiceImpl.searchCount()`**
>        1. **`buildSearchContext()`**
>        1. `DefaultIndexer.search()`
>            1. `IndexerSearcherImpl.searchCount()`
>                1. `IndexerSearcherImpl._search()`
>                    1. `DefaultSearchResultPermissionFilter.search()`
>                        1. **`isGroupAdmin()`**
>                        1. **`filterHits()`**
>    1. **`UserLocalServiceImpl.search()`**
>        1. **`buildSearchContext()`**
>        1. `DefaultIndexer.search()`
>            1. `IndexerSearcherImpl.search()`
>                1. `IndexerSearcherImpl._search()`
>                    1. `DefaultSearchResultPermissionFilter.search()`
>                        1. **`isGroupAdmin()`**
>                        1. **`SlidingWindowSearcher.search()`**
>
>`isGroupAdmin()` checks for a `groupId` attribute on the `SearchContext`, which is created via `buildSearchContext()`. However, this attribute is non-existent, and as a result, the logic in the outermost `searchCount()` and `search()` calls incorrectly fall into routines that filter and iterate through the users (via a sliding window), respectively -- these two routines are responsible for the performance hit.
>
>## Solution :tada:
>
>We introduce the `groupId` attribute by deprecating relevant methods that only pass in a `long companyId` in favor of methods that pass in a `ThemeDisplay` instead. From the `ThemeDisplay`, we can retrieve both the company and group IDs, which we use to build the `SearchContext`, thus allowing the `isGroupAdmin()` check to pass for Site Administrators.