### PR TITLE
[TS] LPS-105757

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -196,7 +196,7 @@ public class DefaultSearchResultPermissionFilter
 
 	protected boolean isGroupAdmin(SearchContext searchContext) {
 		long groupId = GetterUtil.getLong(
-			searchContext.getAttribute(Field.GROUP_ID));
+			searchContext.getAttribute("usersGroups"));
 
 		if (groupId == 0) {
 			return false;

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
@@ -181,6 +181,9 @@ public class SelectUsersDisplayContext {
 			userParams.put(
 				"usersGroups", Long.valueOf(group.getParentGroupId()));
 		}
+		else {
+			userParams.put("usersGroups", getGroupId());
+		}
 
 		int usersCount = UserLocalServiceUtil.searchCount(
 			themeDisplay.getCompanyId(), searchTerms.getKeywords(),

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5715,6 +5715,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		attributes.put("screenName", screenName);
 		attributes.put("status", status);
 		attributes.put("street", street);
+		attributes.put(
+			"usersGroups", (Long)params.getOrDefault("usersGroups", 0));
 		attributes.put("zip", zip);
 
 		searchContext.setAttributes(attributes);


### PR DESCRIPTION
From @jesseyeh-liferay:

## Previous Pull Requests

1. https://github.com/wanderlast/liferay-portal/pull/35 > https://github.com/ChrisKian/liferay-portal/pull/163 > https://github.com/drewbrokke/liferay-portal/pull/939
1. https://github.com/ChrisKian/liferay-portal/pull/164 > https://github.com/pei-jung/liferay-portal/pull/549

## Changelog

* Add `groupId` as `usersGroups` in the `params` map when building the `SearchContext`
* Replace the search for the "groupId" attribute to "usersGroups" instead

>## Problem :grimacing:
>
>**[LPS-105757](https://issues.liferay.com/browse/LPS-105757)**
>
>When a Site Administrator attempts to add users to a site via the "Assign Users to This Site" popup from a large pool of users (e.g., 25,000+ users), the popup experiences a big performance hit before the users are (incorrectly) displayed.
>
>## Analysis :nerd_face:
>
>#### Overview
>
>The original implementation's logic flow is summarized as follows (key areas bolded):
>
>1. `SelectUsersDisplayContext.getUserSearchContainer()`
>    1. **`UserLocalServiceImpl.searchCount()`**
>        1. **`buildSearchContext()`**
>        1. `DefaultIndexer.search()`
>            1. `IndexerSearcherImpl.searchCount()`
>                1. `IndexerSearcherImpl._search()`
>                    1. `DefaultSearchResultPermissionFilter.search()`
>                        1. **`isGroupAdmin()`**
>                        1. **`filterHits()`**
>    1. **`UserLocalServiceImpl.search()`**
>        1. **`buildSearchContext()`**
>        1. `DefaultIndexer.search()`
>            1. `IndexerSearcherImpl.search()`
>                1. `IndexerSearcherImpl._search()`
>                    1. `DefaultSearchResultPermissionFilter.search()`
>                        1. **`isGroupAdmin()`**
>                        1. **`SlidingWindowSearcher.search()`**
>
>`isGroupAdmin()` checks for a `groupId` attribute on the `SearchContext`, which is created via `buildSearchContext()`. However, this attribute is non-existent, and as a result, the logic in the outermost `searchCount()` and `search()` calls incorrectly fall into routines that filter and iterate through the users (via a sliding window), respectively -- these two routines are responsible for the performance hit.
>

## Solution :tada:

We introduce the `usersGroups` attribute by forwarding the `groupId` when building the `SearchContext`. Doing so allows the `isGroupAdmin()` check to pass for Site Administrators.