### PR TITLE
LPS-107527 Add test to check if the site admin is able to add users to a site

### DIFF
--- a/modules/apps/message-boards/message-boards-service/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-service/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Message Boards Service
 Bundle-SymbolicName: com.liferay.message.boards.service
 Bundle-Version: 4.0.4
 Import-Package:\
-	com.liferay.portal.kernel.search;version="[8.1.0,9.1.0)",\
+	com.liferay.portal.kernel.search;version="[8.1.0,9.2.0)",\
 	\
 	*
 Liferay-Require-SchemaVersion: 3.0.0

--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -54,7 +54,7 @@ Export-Package:\
 	com.liferay.portal.search.summary,\
 	com.liferay.portal.search.synonym
 Import-Package:\
-	com.liferay.portal.kernel.search;version="[8.1.0,9.1.0)",\
+	com.liferay.portal.kernel.search;version="[8.1.0,9.2.0)",\
 	\
 	*
 -dsannotations-options: inherit

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/bnd.bnd
@@ -10,6 +10,6 @@ Export-Package:\
 	com.liferay.portal.search.engine.adapter.search,\
 	com.liferay.portal.search.engine.adapter.snapshot
 Import-Package:\
-	com.liferay.portal.kernel.search;version="[8.1.0,9.1.0)",\
+	com.liferay.portal.kernel.search;version="[8.1.0,9.2.0)",\
 	\
 	*

--- a/modules/apps/portal-search/portal-search-spi/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-spi/bnd.bnd
@@ -13,6 +13,6 @@ Export-Package:\
 	com.liferay.portal.search.spi.model.result.contributor,\
 	com.liferay.portal.search.spi.searcher
 Import-Package:\
-	com.liferay.portal.kernel.search;version="[8.1.0,9.1.0)",\
+	com.liferay.portal.kernel.search;version="[8.1.0,9.2.0)",\
 	\
 	*

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/SearchPermissionCheckerTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/SearchPermissionCheckerTest.java
@@ -158,7 +158,8 @@ public class SearchPermissionCheckerTest {
 
 		assertFieldValue(
 			null, Field.GROUP_ID, String.valueOf(_group.getGroupId()));
-		assertFieldValue(null, Field.ROLE_ID, String.valueOf(role.getRoleId()));
+		assertFieldValue(
+			null, Field.ROLE_IDS, String.valueOf(role.getRoleId()));
 	}
 
 	@Test
@@ -199,7 +200,7 @@ public class SearchPermissionCheckerTest {
 			new long[] {_group.getGroupId()}, Field.GROUP_ID,
 			String.valueOf(_group.getGroupId()));
 		assertFieldValue(
-			new long[] {_group.getGroupId()}, Field.ROLE_ID,
+			new long[] {_group.getGroupId()}, Field.ROLE_IDS,
 			String.valueOf(role.getRoleId()));
 	}
 
@@ -220,7 +221,8 @@ public class SearchPermissionCheckerTest {
 
 		assertFieldValue(
 			null, Field.GROUP_ID, String.valueOf(_organization.getGroupId()));
-		assertFieldValue(null, Field.ROLE_ID, String.valueOf(role.getRoleId()));
+		assertFieldValue(
+			null, Field.ROLE_IDS, String.valueOf(role.getRoleId()));
 	}
 
 	@Test

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/UserSearchTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/UserSearchTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.users.admin.kernel.util.UsersAdminUtil;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jesse Yeh
+ */
+@RunWith(Arquillian.class)
+public class UserSearchTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_groupAdminUser = UserTestUtil.addGroupAdminUser(_group);
+		_groupMemberUser = UserTestUtil.addGroupUser(
+			_group, RoleConstants.SITE_MEMBER);
+
+		_nonGroupMemberUser = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testSearchUsersAsGroupAdmin() throws Exception {
+		Long[] testUserIds = {
+			_groupAdminUser.getUserId(), _groupMemberUser.getUserId(),
+			_nonGroupMemberUser.getUserId()
+		};
+
+		Stream<User> usersStream = _getUsers().stream();
+
+		List<Long> userIds = usersStream.map(
+			User::getUserId
+		).collect(
+			Collectors.toList()
+		);
+
+		Assert.assertTrue(
+			Stream.of(
+				testUserIds
+			).allMatch(
+				userIds::contains
+			));
+	}
+
+	private List<User> _getUsers() throws Exception {
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(_groupAdminUser));
+
+		LinkedHashMap<String, Object> userParams =
+			LinkedHashMapBuilder.<String, Object>put(
+				Field.GROUP_ID, Long.valueOf(_groupAdminUser.getGroupIds()[0])
+			).build();
+
+		String keywords = "";
+		int status = 0;
+		int start = 0;
+		int end = 20;
+
+		Hits hits = _userLocalService.search(
+			TestPropsValues.getCompanyId(), keywords, status, userParams, start,
+			end, new Sort());
+
+		return UsersAdminUtil.getUsers(hits);
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private User _groupAdminUser;
+
+	@DeleteAfterTestRun
+	private User _groupMemberUser;
+
+	@DeleteAfterTestRun
+	private User _nonGroupMemberUser;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal-search/portal-search/bnd.bnd
+++ b/modules/apps/portal-search/portal-search/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Portal Search
 Bundle-SymbolicName: com.liferay.portal.search
 Bundle-Version: 7.0.2
 Import-Package:\
-	com.liferay.portal.kernel.search;version="[8.1.0,9.1.0)",\
+	com.liferay.portal.kernel.search;version="[8.1.0,9.2.0)",\
 	\
 	*
 -dsannotations-options: inherit

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
@@ -672,7 +672,7 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 		private final long[] _regularRoleIds;
 		private final long[] _roleIds;
 		private final TermsFilter _rolesTermsFilter = new TermsFilter(
-			Field.ROLE_ID);
+			Field.ROLE_IDS);
 		private final List<UsersGroupIdRoles> _usersGroupIdsRoles;
 
 	}

--- a/modules/apps/wiki/wiki-service/bnd.bnd
+++ b/modules/apps/wiki/wiki-service/bnd.bnd
@@ -37,7 +37,7 @@ Import-Package:\
 	\
 	!org.jgroups.*,\
 	\
-	com.liferay.portal.kernel.search;version="[8.1.0,9.1.0)",\
+	com.liferay.portal.kernel.search;version="[8.1.0,9.2.0)",\
 	\
 	*
 Liferay-Require-SchemaVersion: 2.1.0

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 5.4.1
+Bundle-Version: 5.5.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Field.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Field.java
@@ -135,6 +135,8 @@ public class Field implements Serializable {
 
 	public static final String ROLE_ID = "roleId";
 
+	public static final String ROLE_IDS = "roleIds";
+
 	public static final String ROOT_ENTRY_CLASS_NAME = "rootEntryClassName";
 
 	public static final String ROOT_ENTRY_CLASS_PK = "rootEntryClassPK";

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0


### PR DESCRIPTION
## Previous Pull Requests

1. https://github.com/wanderlast/liferay-portal/pull/40 > https://github.com/ChrisKian/liferay-portal/pull/178 > https://github.com/drewbrokke/liferay-portal/pull/961 > https://github.com/mhan810/liferay-portal/pull/1485

## Changelog

* Add test to check if site admins are able to add users to a site

>## Problem :grimacing:
>
>**[LPS-107527](https://issues.liferay.com/browse/LPS-107527)**
>
>Site admins are unable to add new users to a site via Site > People > Membership. This is in contrast to the omni-admin, which does not experience the same issue.
>
>## Analysis :nerd_face:
>
>As the omni-admin, all the users are displayed when attempting to add new users to a site. However, the pool of users displayed to a site admin is incomplete.
>
>[Diff of the omni-admin (left) and site admin (right) search queries](https://github.com/jesseyeh-liferay/liferay-portal-ee/compare/2af465b..b3f9b4d)
>
>The site admin query mandates that at least of the conditions in the above diff is true. The following condition in particular
>
>| Condition | Description |
>| --------- | ----------- |
>| <pre>"terms": {<br>    "roleId" [<br>        "20104",<br>        "20112",<br>        "20111",<br>        "20107",<br>    "boost": 1<br>\}</pre> | `20104` - Guest<br>`20112` - Site Administrator<br>`20111` - Site Member<br>`20107` - User |
>
>requires that the users to be displayed must have a matching `roleId`. However, if we create a regular, dummy user and examine its sources
>
>```
>{
>    ...
>    "_source": {
>        ...
>        "roleId": "20105",
>        "fullName": "dummy user",
>        ...
>        "roleIds": "20107",
>        ...
>    }
>}
>```
>
>we can see that a `roleId` of `20105` (Owner) is missing above, and the relevant role (`20107`) is instead contained within `roleIds`.
>
>## Solution :tada:
>
>We alter the query so that `roleId` is instead `roleIds`.
>
>## Additional Notes :memo:
>
>The issue with the site admin not being able to add users can be seen as far back as 7.2 GA1. It is, however, functioning properly on `7.1.x`. Comparing `master` to `7.1.x` reveals a divergence in logic in which [`master` passes a conditional check and proceeds onto permissions filter logic](https://github.com/jesseyeh-liferay/liferay-portal/blob/master/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerSearcherImpl.java#L118), whereas [`7.1.x` fails a similar check](https://github.com/jesseyeh-liferay/liferay-portal-ee/blob/a92d39153a1b0445e5d0edc029616a8d5ed8e71b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java#L683).