### PR TITLE
LPS-109117 Roles admin should only display shared account roles

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/dao/search/AccountRoleRowChecker.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/dao/search/AccountRoleRowChecker.java
@@ -15,8 +15,9 @@
 package com.liferay.account.admin.web.internal.dao.search;
 
 import com.liferay.account.admin.web.internal.display.AccountRoleDisplay;
-import com.liferay.account.constants.AccountRoleConstants;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 
 import javax.portlet.PortletResponse;
 
@@ -33,7 +34,9 @@ public class AccountRoleRowChecker extends EmptyOnClickRowChecker {
 	public boolean isDisabled(Object obj) {
 		AccountRoleDisplay accountRoleDisplay = (AccountRoleDisplay)obj;
 
-		if (AccountRoleConstants.isRequiredRole(accountRoleDisplay.getRole())) {
+		Role role = accountRoleDisplay.getRole();
+
+		if (role.getType() == RoleConstants.TYPE_ACCOUNT) {
 			return true;
 		}
 

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role_action.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role_action.jsp
@@ -22,6 +22,8 @@ AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttrib
 ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 
 AccountRoleDisplay accountRoleDisplay = (AccountRoleDisplay)row.getObject();
+
+Role role = accountRoleDisplay.getRole();
 %>
 
 <liferay-ui:icon-menu
@@ -31,7 +33,7 @@ AccountRoleDisplay accountRoleDisplay = (AccountRoleDisplay)row.getObject();
 	message="<%= StringPool.BLANK %>"
 	showWhenSingleIcon="<%= true %>"
 >
-	<c:if test="<%= !AccountRoleConstants.isRequiredRole(accountRoleDisplay.getRole()) %>">
+	<c:if test="<%= role.getType() != RoleConstants.TYPE_ACCOUNT %>">
 		<portlet:renderURL var="editAccountRoleURL">
 			<portlet:param name="mvcPath" value="/account_entries_admin/edit_account_role.jsp" />
 			<portlet:param name="backURL" value="<%= currentURL %>" />

--- a/modules/apps/account/account-service/bnd.bnd
+++ b/modules/apps/account/account-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Account Service
 Bundle-SymbolicName: com.liferay.account.service
 Bundle-Version: 1.0.6
-Liferay-Require-SchemaVersion: 1.0.0
+Liferay-Require-SchemaVersion: 1.0.7
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/account/account-service/build.gradle
+++ b/modules/apps/account/account-service/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
+	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:roles:roles-admin-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/instance/lifecycle/AddDefaultAccountRolesPortalInstanceLifecycleListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/instance/lifecycle/AddDefaultAccountRolesPortalInstanceLifecycleListener.java
@@ -52,7 +52,7 @@ public class AddDefaultAccountRolesPortalInstanceLifecycleListener
 		User defaultUser = company.getDefaultUser();
 
 		if (!_exists(AccountRoleConstants.REQUIRED_ROLE_NAME_ACCOUNT_USER)) {
-			AccountRole accountRole = _addAccountRole(
+			Role accountRole = _addAccountRole(
 				defaultUser.getUserId(),
 				AccountRoleConstants.REQUIRED_ROLE_NAME_ACCOUNT_USER);
 
@@ -63,7 +63,7 @@ public class AddDefaultAccountRolesPortalInstanceLifecycleListener
 		if (!_exists(
 				AccountRoleConstants.REQUIRED_ROLE_NAME_ACCOUNT_POWER_USER)) {
 
-			AccountRole accountRole = _addAccountRole(
+			Role accountRole = _addAccountRole(
 				defaultUser.getUserId(),
 				AccountRoleConstants.REQUIRED_ROLE_NAME_ACCOUNT_POWER_USER);
 
@@ -89,15 +89,16 @@ public class AddDefaultAccountRolesPortalInstanceLifecycleListener
 		}
 	}
 
-	private AccountRole _addAccountRole(long userId, String roleName)
+	private Role _addAccountRole(long userId, String roleName)
 		throws PortalException {
 
-		return _accountRoleLocalService.addAccountRole(
-			userId, AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT, roleName,
+		return _roleLocalService.addRole(
+			userId, AccountRole.class.getName(),
+			AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT, roleName,
 			HashMapBuilder.put(
 				LocaleThreadLocal.getDefaultLocale(), roleName
 			).build(),
-			null);
+			null, RoleConstants.TYPE_REGULAR, null, null);
 	}
 
 	private void _addResourcePermissions(

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/RoleModelListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/RoleModelListener.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.exception.RequiredRoleException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
@@ -49,6 +50,10 @@ public class RoleModelListener extends BaseModelListener<Role> {
 				role.getClassNameId(),
 				_portal.getClassNameId(AccountRole.class))) {
 
+			return;
+		}
+
+		if (!Objects.equals(role.getType(), RoleConstants.TYPE_ACCOUNT)) {
 			return;
 		}
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/roles/admin/role/type/contributor/AccountRoleTypeContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/roles/admin/role/type/contributor/AccountRoleTypeContributor.java
@@ -75,7 +75,7 @@ public class AccountRoleTypeContributor implements RoleTypeContributor {
 
 	@Override
 	public int getType() {
-		return RoleConstants.TYPE_PROVIDER;
+		return RoleConstants.TYPE_ACCOUNT;
 	}
 
 	@Override

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/upgrade/AccountServiceUpgrade.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/upgrade/AccountServiceUpgrade.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.upgrade;
+
+import com.liferay.account.internal.upgrade.v1_0_7.UpgradeAccountRoleType;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Component(immediate = true, service = UpgradeStepRegistrator.class)
+public class AccountServiceUpgrade implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.register("1.0.0", "1.0.7", new UpgradeAccountRoleType());
+	}
+
+}

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/upgrade/v1_0_7/UpgradeAccountRoleType.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/upgrade/v1_0_7/UpgradeAccountRoleType.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.upgrade.v1_0_7;
+
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountRole;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Pei-Jung Lan
+ */
+public class UpgradeAccountRoleType extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append("select distinct Role_.roleId from Role_ inner join ");
+			sb.append("AccountRole on AccountRole.roleId = Role_.roleId ");
+			sb.append("where Role_.classNameId = ");
+			sb.append(PortalUtil.getClassNameId(AccountRole.class));
+			sb.append(" and Role_.type_ = ");
+			sb.append(RoleConstants.TYPE_PROVIDER);
+			sb.append(" and AccountRole.accountEntryId = ");
+			sb.append(AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT);
+
+			try (PreparedStatement ps1 = connection.prepareStatement(
+					sb.toString());
+				PreparedStatement ps2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection.prepareStatement(
+							"update Role_ set type_ = " +
+								RoleConstants.TYPE_ACCOUNT +
+									" where roleId = ?"))) {
+
+				try (ResultSet rs = ps1.executeQuery()) {
+					while (rs.next()) {
+						long roleId = rs.getLong("roleId");
+
+						ps2.setLong(1, roleId);
+
+						ps2.addBatch();
+					}
+
+					ps2.executeBatch();
+				}
+			}
+		}
+	}
+
+}

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
@@ -453,7 +453,8 @@ public class RolesAdminPortlet extends MVCPortlet {
 
 				int scope = ResourceConstants.SCOPE_COMPANY;
 
-				if ((role.getType() == RoleConstants.TYPE_DEPOT) ||
+				if ((role.getType() == RoleConstants.TYPE_ACCOUNT) ||
+					(role.getType() == RoleConstants.TYPE_DEPOT) ||
 					(role.getType() == RoleConstants.TYPE_ORGANIZATION) ||
 					(role.getType() == RoleConstants.TYPE_PROVIDER) ||
 					(role.getType() == RoleConstants.TYPE_SITE)) {

--- a/portal-impl/src/com/liferay/portal/security/permission/PermissionConverterImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/PermissionConverterImpl.java
@@ -69,7 +69,8 @@ public class PermissionConverterImpl implements PermissionConverter {
 				ResourceConstants.SCOPE_COMPANY, ResourceConstants.SCOPE_GROUP
 			};
 		}
-		else if ((role.getType() == RoleConstants.TYPE_DEPOT) ||
+		else if ((role.getType() == RoleConstants.TYPE_ACCOUNT) ||
+				 (role.getType() == RoleConstants.TYPE_DEPOT) ||
 				 (role.getType() == RoleConstants.TYPE_ORGANIZATION) ||
 				 (role.getType() == RoleConstants.TYPE_PROVIDER) ||
 				 (role.getType() == RoleConstants.TYPE_SITE)) {

--- a/portal-kernel/src/com/liferay/portal/kernel/model/role/RoleConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/role/RoleConstants.java
@@ -80,6 +80,10 @@ public class RoleConstants {
 		SITE_ADMINISTRATOR, SITE_MEMBER, SITE_OWNER
 	};
 
+	public static final int TYPE_ACCOUNT = 6;
+
+	public static final String TYPE_ACCOUNT_LABEL = "account";
+
 	public static final int TYPE_DEPOT = 5;
 
 	public static final String TYPE_DEPOT_LABEL = "depot";
@@ -130,7 +134,10 @@ public class RoleConstants {
 	}
 
 	public static String getTypeLabel(int type) {
-		if (type == TYPE_DEPOT) {
+		if (type == TYPE_ACCOUNT) {
+			return TYPE_ACCOUNT_LABEL;
+		}
+		else if (type == TYPE_DEPOT) {
 			return TYPE_DEPOT_LABEL;
 		}
 		else if (type == TYPE_ORGANIZATION) {


### PR DESCRIPTION
Hey Drew,

I ended up creating a new role type for account role because we need to distinguish between shared account roles and specific account roles. Currently, account roles that are created in the accounts portlet show up in the Roles Admin portlet, and they need to be excluded from the account roles list in Roles Admin.

After some thoughts, I think shared account roles work like site roles, so it makes sense to have a new type for it. And the specific account roles are like team roles, which is provided an account, so it's a provider role.

Let me know what you think.