### PR TITLE
LPS-109676 Use right icon.

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/build.gradle
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.configuration.web.internal.display.context;
 
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -347,7 +348,8 @@ public class PortletConfigurationPermissionsDisplayContext {
 
 			if ((modelResourceRole.getType() ==
 					RoleConstants.TYPE_ORGANIZATION) ||
-				(modelResourceRole.getType() == RoleConstants.TYPE_SITE)) {
+				(modelResourceRole.getType() == RoleConstants.TYPE_SITE) ||
+				(modelResourceRole.getType() == RoleConstants.TYPE_DEPOT)) {
 
 				filterGroupRoles = true;
 			}
@@ -408,6 +410,9 @@ public class PortletConfigurationPermissionsDisplayContext {
 		excludedRoleNames.add(RoleConstants.ADMINISTRATOR);
 
 		if (filterGroupRoles) {
+			excludedRoleNames.add(
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+			excludedRoleNames.add(DepotRolesConstants.ASSET_LIBRARY_OWNER);
 			excludedRoleNames.add(RoleConstants.ORGANIZATION_ADMINISTRATOR);
 			excludedRoleNames.add(RoleConstants.ORGANIZATION_OWNER);
 			excludedRoleNames.add(RoleConstants.SITE_ADMINISTRATOR);

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -74,6 +74,10 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 							icon = "organizations";
 							message = "organization-role";
 						}
+						else if (roleType == RoleConstants.TYPE_DEPOT) {
+							icon = "books";
+							message = "asset-library-role";
+						}
 						%>
 
 						<liferay-ui:icon


### PR DESCRIPTION
Hey @drewbrokke,

We need to filter the Depot Roles, the same way we do with the Site roles.

Here you have an example of what we need to do, but probably is not a good idea for *portlet-configuration-web* to depends on *depot-api*, so maybe we need a Provider to help exclude some roles.

What do you think? If you think another architecture is better, you can tell us and we would be able to implement it.

/cc @adolfopa @AliciaGarciaGarcia