### PR TITLE
[TS] LPS-111656

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserOrganizationsMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserOrganizationsMVCActionCommand.java
@@ -75,6 +75,9 @@ public class EditUserOrganizationsMVCActionCommand
 			ServiceContext serviceContext = ServiceContextFactory.getInstance(
 				User.class.getName(), actionRequest);
 
+			serviceContext.setAssetCategoryIds(null);
+			serviceContext.setAssetTagNames(null);
+
 			_userService.updateUser(
 				user.getUserId(), user.getPassword(), null, null,
 				user.isPasswordReset(), null, null, user.getScreenName(),

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateMembershipsMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateMembershipsMVCActionCommand.java
@@ -73,6 +73,9 @@ public class UpdateMembershipsMVCActionCommand extends BaseMVCActionCommand {
 			ServiceContext serviceContext = ServiceContextFactory.getInstance(
 				User.class.getName(), actionRequest);
 
+			serviceContext.setAssetCategoryIds(null);
+			serviceContext.setAssetTagNames(null);
+
 			_userService.updateUser(
 				user.getUserId(), user.getPassword(), null, null,
 				user.isPasswordReset(), null, null, user.getScreenName(),

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateUserRolesMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateUserRolesMVCActionCommand.java
@@ -117,6 +117,9 @@ public class UpdateUserRolesMVCActionCommand extends BaseMVCActionCommand {
 			ServiceContext serviceContext = ServiceContextFactory.getInstance(
 				User.class.getName(), actionRequest);
 
+			serviceContext.setAssetCategoryIds(null);
+			serviceContext.setAssetTagNames(null);
+
 			user = _userService.updateUser(
 				user.getUserId(), user.getPassword(), null, null,
 				user.isPasswordReset(), null, null, user.getScreenName(),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-111656

Original message from @NemethNorbert:

> Hey,
> 
> [LPS-111656](https://issues.liferay.com/browse/LPS-111656)
> Based on the purpose of [this commit](https://github.com/brianchandotcom/liferay-portal/pull/65603/commits/46a73e989b1acdb5da016f7416cefffcc2b16967)
> 
> I decided to set the assetCategoriesId and assetTagNames to null in case we don't want to update them. I included the assetTagNames, as the issue was also reproducible with it.
> 
> As I know we investigated this issue and possible solutions from a variety of angles, I'd like to say this PR is focusing solely on the issue of losing already saved configuration in case we are saving on a different tab.
> Saving unsaved configuration on an a different tab is currently considered a product limitation, and I think it should be introduced as a new feature on a different ticket.
> 
> Please review my changes,
> 
> Thanks

CC @antonio-ortega

Also, this issue is much easier to test with just Tags.  Thanks!