### PR TITLE
LPS-112965 uses generic "type" language key for asset libraries, organizations and site columns in the role selection

### DIFF
--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
@@ -54,7 +54,7 @@ DepotAdminSelectRoleDisplayContext depotAdminSelectRoleDisplayContext = (DepotAd
 					/>
 
 					<liferay-ui:search-container-column-text
-						name="roleType"
+						name="type"
 						value=""
 					/>
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
@@ -114,7 +114,7 @@ else {
 					/>
 
 					<liferay-ui:search-container-column-text
-						name="roleType"
+						name="type"
 						orderable="<%= true %>"
 						value="<%= LanguageUtil.get(request, organization.getType()) %>"
 					/>

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -107,7 +107,7 @@ SearchContainer roleSearchContainer = selectRoleManagementToolbarDisplayContext.
 					/>
 
 					<liferay-ui:search-container-column-text
-						name="roleType"
+						name="type"
 						value="<%= LanguageUtil.get(request, group.getTypeLabel()) %>"
 					/>
 


### PR DESCRIPTION
Hi @drewbrokke 

We changed the label on the selector of roles on the sites/asset libraries/organization to "type" instead of "roleType" that didn't exist.

Can you check if this change is ok?

Thanks!