### PR TITLE
LPS-112965 Missing literal for Role Type when adding an Asset Library role

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -97,9 +97,11 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			Group depotGroup = null;
 
 			if (StringUtil.equals(name, Group.class.getName())) {
-				depotGroup = _groupLocalService.getGroup(primKey);
+				depotGroup = _groupLocalService.fetchGroup(primKey);
 
-				if (depotGroup.getType() != GroupConstants.TYPE_DEPOT) {
+				if ((depotGroup != null) &&
+					(depotGroup.getType() != GroupConstants.TYPE_DEPOT)) {
+
 					depotGroup = null;
 				}
 			}

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
@@ -54,7 +54,7 @@ DepotAdminSelectRoleDisplayContext depotAdminSelectRoleDisplayContext = (DepotAd
 					/>
 
 					<liferay-ui:search-container-column-text
-						name="roleType"
+						name="type"
 						value=""
 					/>
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
@@ -114,7 +114,7 @@ else {
 					/>
 
 					<liferay-ui:search-container-column-text
-						name="roleType"
+						name="type"
 						orderable="<%= true %>"
 						value="<%= LanguageUtil.get(request, organization.getType()) %>"
 					/>

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -107,7 +107,7 @@ SearchContainer roleSearchContainer = selectRoleManagementToolbarDisplayContext.
 					/>
 
 					<liferay-ui:search-container-column-text
-						name="roleType"
+						name="type"
 						value="<%= LanguageUtil.get(request, group.getTypeLabel()) %>"
 					/>
 


### PR DESCRIPTION
This is an update for [LPS-112965](https://issues.liferay.com/browse/LPS-112965).<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez @AliciaGarciaGarcia @adolfopa