### PR TITLE
LPS-113462 Escape openId in login portlet

### DIFF
--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
@@ -33,7 +33,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "create-account"));
 
 <c:if test="<%= Validator.isNotNull(openId) %>">
 	<div class="alert alert-info">
-		<liferay-ui:message arguments="<%= openId %>" key="you-are-about-to-create-an-account-with-openid-x" translateArguments="<%= false %>" />
+		<liferay-ui:message arguments="<%= HtmlUtil.escape(openId) %>" key="you-are-about-to-create-an-account-with-openid-x" translateArguments="<%= false %>" />
 	</div>
 </c:if>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-113462

Notes from @amandaaakwok
>Issue: An XSS vulnerability is introduced when a user edits the value of the openId.
>Solution: The openId should be escaped