### PR TITLE
[TS] LPS-113096

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -175,9 +175,12 @@ public class VirtualHostLocalServiceImpl
 
 			String languageId = hostnames.get(curHostname);
 
-			Locale locale = LocaleUtil.fromLanguageId(languageId);
+			Locale locale;
 
-			if (languageId == null) {
+			if (languageId != null) {
+				locale = LocaleUtil.fromLanguageId(languageId);
+			}
+			else {
 				locale = LocaleUtil.getSiteDefault();
 			}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -177,6 +177,10 @@ public class VirtualHostLocalServiceImpl
 
 			Locale locale = LocaleUtil.fromLanguageId(languageId);
 
+			if (languageId == null) {
+				locale = LocaleUtil.getSiteDefault();
+			}
+
 			if (!availableLocales.contains(locale)) {
 				ReflectionUtil.throwException(
 					new AvailableLocaleException(languageId));

--- a/portal-kernel/src/com/liferay/portal/kernel/util/LocaleUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/LocaleUtil.java
@@ -224,7 +224,7 @@ public class LocaleUtil {
 
 		if (languageId == null) {
 			if (useDefault) {
-				return _locale;
+				return _getDefault();
 			}
 
 			return null;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-113096

From @wanderlast:

> This PR technically is fixed by the second commit alone, but I felt like the first commit seemed to be a logical oversight and therefore included it. The issue is that, currently, LocalUtil._locale is hardcoded to correspond with EN-US. Therefore when LocaleUtil.fromLanguageId(languageId) is called when languageId is null (which is the case when 'default language' is selected in the virtual hosts menu), the locale selected will always be EN-US. This causes problems with the subsequent error checking for any portal that has removed EN-US as a locale option. Therefore, if the hostname doesn't have a language attached to it, we should simply check for the site default locale. Please let me know if you have any questions. Thanks!