### PR TITLE
LPS-114004 Replace layout classes with new clay taglibs in account-admin-web

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/categorization.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/categorization.jsp
@@ -24,7 +24,7 @@ AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttrib
 
 <liferay-asset:asset-tags-error />
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle">
 		<%= LanguageUtil.get(request, "more-information") %>
 	</h3>
@@ -43,4 +43,4 @@ AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttrib
 			groupIds="<%= new long[] {themeDisplay.getCompanyGroupId()} %>"
 		/>
 	</div>
-</div>
+</clay:sheet-section>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/display_data.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/display_data.jsp
@@ -20,7 +20,7 @@
 AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttribute(AccountWebKeys.ACCOUNT_ENTRY_DISPLAY);
 %>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle">
 		<%= LanguageUtil.get(request, "account-display-data") %>
 	</h3>
@@ -59,4 +59,4 @@ AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttrib
 	<aui:field-wrapper cssClass="form-group lfr-input-text-container">
 		<aui:input label="" labelOff="inactive" labelOn="active" name="active" type="toggle-switch" value="<%= (accountEntryDisplay == null) ? true : accountEntryDisplay.isActive() %>" />
 	</aui:field-wrapper>
-</div>
+</clay:sheet-section>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -38,12 +38,18 @@ if (accountEntryDisplay != null) {
 	/>
 </liferay-util:buffer>
 
-<div class="sheet-section">
-	<h3 class="autofit-row sheet-subtitle">
-		<span class="autofit-col autofit-col-expand">
+<clay:sheet-section>
+	<clay:content-row
+		className="sheet-subtitle"
+		containerElement="h3"
+	>
+		<clay:content-col
+			expand="true"
+		>
 			<span class="heading-text"><liferay-ui:message key="valid-domains" /></span>
-		</span>
-		<span class="autofit-col">
+		</clay:content-col>
+
+		<clay:content-col>
 			<span class="heading-end">
 				<liferay-ui:icon
 					cssClass="modify-link"
@@ -55,8 +61,8 @@ if (accountEntryDisplay != null) {
 					url="javascript:;"
 				/>
 			</span>
-		</span>
-	</h3>
+		</clay:content-col>
+	</clay:content-row>
 
 	<aui:input name="domains" type="hidden" value="<%= StringUtil.merge(domains) %>" />
 
@@ -91,7 +97,7 @@ if (accountEntryDisplay != null) {
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:sheet-section>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/parent_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/parent_account_entry.jsp
@@ -38,12 +38,18 @@ if (accountEntryDisplay != null) {
 	/>
 </liferay-util:buffer>
 
-<div class="sheet-section">
-	<h3 class="autofit-row sheet-subtitle">
-		<span class="autofit-col autofit-col-expand">
+<clay:sheet-section>
+	<clay:content-row
+		className="sheet-subtitle"
+		containerElement="h3"
+	>
+		<clay:content-col
+			expand="true"
+		>
 			<span class="heading-text"><liferay-ui:message key="parent-account" /></span>
-		</span>
-		<span class="autofit-col">
+		</clay:content-col>
+
+		<clay:content-col>
 			<span class="heading-end">
 				<liferay-ui:icon
 					cssClass="modify-link"
@@ -55,8 +61,8 @@ if (accountEntryDisplay != null) {
 					url="javascript:;"
 				/>
 			</span>
-		</span>
-	</h3>
+		</clay:content-col>
+	</clay:content-row>
 
 	<aui:input name="parentAccountEntryId" type="hidden" value="<%= (parentAccountEntry != null) ? String.valueOf(parentAccountEntry.getAccountEntryId()) : AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT %>" />
 
@@ -92,7 +98,7 @@ if (accountEntryDisplay != null) {
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:sheet-section>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/add_account_user.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/add_account_user.jsp
@@ -54,7 +54,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "add-new-user-to-x", accoun
 			<%= LanguageUtil.get(request, "information") %>
 		</h2>
 
-		<div class="sheet-section">
+		<clay:sheet-section>
 			<h3 class="sheet-subtitle">
 				<%= LanguageUtil.get(request, "user-display-data") %>
 			</h3>
@@ -115,7 +115,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "add-new-user-to-x", accoun
 					</div>
 				</clay:col>
 			</clay:row>
-		</div>
+		</clay:sheet-section>
 	</liferay-frontend:edit-form-body>
 
 	<liferay-frontend:edit-form-footer>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
@@ -50,18 +50,24 @@ portletDisplay.setURLBack(backURL);
 	<aui:input name="addAccountEntryIds" type="hidden" />
 	<aui:input name="deleteAccountEntryIds" type="hidden" />
 
-	<div class="sheet sheet-lg">
+	<clay:sheet>
 		<h2 class="sheet-title">
 			<%= LanguageUtil.get(request, "accounts") %>
 		</h2>
 
-		<h3 class="autofit-row sheet-subtitle">
-			<span class="autofit-col autofit-col-expand">
+		<clay:content-row
+			className="sheet-subtitle"
+			containerElement="h3"
+		>
+			<clay:content-col
+				expand="true"
+			>
 				<span class="heading-text">
 					<liferay-ui:message key="accounts" />
 				</span>
-			</span>
-			<span class="autofit-col">
+			</clay:content-col>
+
+			<clay:content-col>
 				<span class="heading-end">
 					<liferay-ui:icon
 						cssClass="modify-link"
@@ -73,10 +79,10 @@ portletDisplay.setURLBack(backURL);
 						url="javascript:;"
 					/>
 				</span>
-			</span>
-		</h3>
+			</clay:content-col>
+		</clay:content-row>
 
-		<div class="sheet-section">
+		<clay:sheet-section>
 			<liferay-ui:search-container
 				compactEmptyResultsMessage="<%= true %>"
 				emptyResultsMessage="this-user-does-not-belong-to-any-accounts"
@@ -116,14 +122,14 @@ portletDisplay.setURLBack(backURL);
 					markupView="lexicon"
 				/>
 			</liferay-ui:search-container>
-		</div>
+		</clay:sheet-section>
 
-		<div class="sheet-footer">
+		<clay:sheet-footer>
 			<aui:button type="submit" />
 
 			<aui:button href="<%= backURL %>" type="cancel" />
-		</div>
-	</div>
+		</clay:sheet-footer>
+	</clay:sheet>
 </aui:form>
 
 <aui:script use="liferay-search-container">


### PR DESCRIPTION
Hey @drewbrokke , this is a simple code replacement that uses the new Clay Taglibs for old code like `<div class="sheet sheet-lg">` > `<clay:sheet>`.

Please, could you check if the module is still showing correctly or reply with instructions to see it?

I can't provide an official documentation right now, we have discussed the whole thing in this pr (https://github.com/liferay/clay/pull/3204) but I'm creating a quick list of the usages found so far in this google sheet (https://docs.google.com/spreadsheets/d/1mXjvokQRqSMuQtpghUAFLb2Igd21zgJvc8whUmV_-EU/edit?usp=sharing)

/cc @jbalsas @marcoscv-work