### PR TITLE
[TS] LPS-114717

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.model.OrganizationModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -135,12 +136,14 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 								permissionChecker, organization))
 					).build();
 
+				Sort[] sorts = null;
+
 				BaseModelSearchResult<Organization> baseModelSearchResult =
 					_organizationLocalService.searchOrganizations(
 						user.getCompanyId(),
 						OrganizationConstants.ANY_PARENT_ORGANIZATION_ID, null,
 						organizationParams, QueryUtil.ALL_POS,
-						QueryUtil.ALL_POS, null);
+						QueryUtil.ALL_POS, sorts);
 
 				if (baseModelSearchResult.getLength() == 0) {
 					return new BaseModelSearchResult<>(

--- a/modules/apps/organizations/organizations-item-selector-web/src/main/java/com/liferay/organizations/item/selector/web/internal/display/context/OrganizationItemSelectorViewDisplayContext.java
+++ b/modules/apps/organizations/organizations-item-selector-web/src/main/java/com/liferay/organizations/item/selector/web/internal/display/context/OrganizationItemSelectorViewDisplayContext.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -143,12 +144,14 @@ public class OrganizationItemSelectorViewDisplayContext {
 		OrganizationSearchTerms organizationSearchTerms =
 			(OrganizationSearchTerms)_searchContainer.getSearchTerms();
 
+		Sort[] sorts = null;
+
 		BaseModelSearchResult<Organization> organizationBaseModelSearchResult =
 			_organizationLocalService.searchOrganizations(
 				CompanyThreadLocal.getCompanyId(),
 				OrganizationConstants.ANY_PARENT_ORGANIZATION_ID,
 				organizationSearchTerms.getKeywords(), null,
-				_searchContainer.getStart(), _searchContainer.getEnd(), null);
+				_searchContainer.getStart(), _searchContainer.getEnd(), sorts);
 
 		_searchContainer.setTotal(
 			organizationBaseModelSearchResult.getLength());

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
@@ -66,6 +66,7 @@ public class OrganizationModelDocumentContributor
 			document.addKeyword(Field.TYPE, organization.getType());
 			document.addTextSortable(
 				"nameTreePath", _buildNameTreePath(organization));
+			document.addTextSortable(Field.TYPE, organization.getType());
 			document.addKeyword(
 				"parentOrganizationId", organization.getParentOrganizationId());
 

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
@@ -32,6 +32,9 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.CountryService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.RegionService;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
@@ -41,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -58,6 +62,8 @@ public class OrganizationModelDocumentContributor
 	@Override
 	public void contribute(Document document, Organization organization) {
 		try {
+			document.setSortableTextFields(_sortableTextFields);
+
 			document.addKeyword(Field.COMPANY_ID, organization.getCompanyId());
 			document.addText(Field.NAME, organization.getName());
 			document.addKeyword(
@@ -66,7 +72,6 @@ public class OrganizationModelDocumentContributor
 			document.addKeyword(Field.TYPE, organization.getType());
 			document.addTextSortable(
 				"nameTreePath", _buildNameTreePath(organization));
-			document.addTextSortable(Field.TYPE, organization.getType());
 			document.addKeyword(
 				"parentOrganizationId", organization.getParentOrganizationId());
 
@@ -77,6 +82,11 @@ public class OrganizationModelDocumentContributor
 		catch (PortalException portalException) {
 			throw new SystemException(portalException);
 		}
+	}
+
+	@Activate
+	protected void activate() {
+		_sortableTextFields = _getSortableTextFields();
 	}
 
 	private String _buildNameTreePath(Organization organization)
@@ -123,6 +133,15 @@ public class OrganizationModelDocumentContributor
 		}
 
 		return countryNames;
+	}
+
+	private String[] _getSortableTextFields() {
+		Set<String> defaultSortableTextFields = SetUtil.fromArray(
+			PropsUtil.getArray(PropsKeys.INDEX_SORTABLE_TEXT_FIELDS));
+
+		defaultSortableTextFields.add("type");
+
+		return defaultSortableTextFields.toArray(new String[0]);
 	}
 
 	private void _populateAddresses(
@@ -197,5 +216,7 @@ public class OrganizationModelDocumentContributor
 
 	@Reference
 	private RegionService _regionService;
+
+	private String[] _sortableTextFields;
 
 }

--- a/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/search/test/OrganizationIndexerIndexedFieldsTest.java
+++ b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/search/test/OrganizationIndexerIndexedFieldsTest.java
@@ -239,6 +239,8 @@ public class OrganizationIndexerIndexedFieldsTest {
 		).put(
 			Field.TYPE, organization.getType()
 		).put(
+			Field.getSortableFieldName(Field.TYPE), organization.getType()
+		).put(
 			Field.USER_ID, String.valueOf(organization.getUserId())
 		).put(
 			Field.USER_NAME, StringUtil.toLowerCase(organization.getUserName())

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewOrganizationsManagementToolbarDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewOrganizationsManagementToolbarDisplayContext.java
@@ -33,8 +33,6 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
-import com.liferay.portal.kernel.search.Sort;
-import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
@@ -225,15 +223,12 @@ public class ViewOrganizationsManagementToolbarDisplayContext {
 
 			organizationParams.put("expandoAttributes", keywords);
 
-			Sort sort = SortFactoryUtil.getSort(
-				Organization.class, organizationSearch.getOrderByCol(),
-				organizationSearch.getOrderByType());
-
 			BaseModelSearchResult<Organization> baseModelSearchResult =
 				OrganizationLocalServiceUtil.searchOrganizations(
 					themeDisplay.getCompanyId(), parentOrganizationId, keywords,
 					organizationParams, organizationSearch.getStart(),
-					organizationSearch.getEnd(), sort);
+					organizationSearch.getEnd(),
+					organizationSearch.getOrderByComparator());
 
 			results = baseModelSearchResult.getBaseModels();
 			total = baseModelSearchResult.getLength();

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -1650,7 +1651,33 @@ public class OrganizationLocalServiceImpl
 	@Override
 	public BaseModelSearchResult<Organization> searchOrganizations(
 			long companyId, long parentOrganizationId, String keywords,
+			LinkedHashMap<String, Object> params, int start, int end,
+			OrderByComparator<Organization> obc)
+		throws PortalException {
+
+		return searchOrganizations(
+			companyId, parentOrganizationId, keywords, params, start, end,
+			getSorts(obc));
+	}
+
+	@Override
+	public BaseModelSearchResult<Organization> searchOrganizations(
+			long companyId, long parentOrganizationId, String keywords,
 			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+		throws PortalException {
+
+		Sort[] sorts = {sort};
+
+		return searchOrganizations(
+			companyId, parentOrganizationId, keywords, params, start, end,
+			sorts);
+	}
+
+	@Override
+	public BaseModelSearchResult<Organization> searchOrganizations(
+			long companyId, long parentOrganizationId, String keywords,
+			LinkedHashMap<String, Object> params, int start, int end,
+			Sort[] sorts)
 		throws PortalException {
 
 		String name = null;
@@ -1681,7 +1708,7 @@ public class OrganizationLocalServiceImpl
 
 		return searchOrganizations(
 			companyId, parentOrganizationId, name, type, street, city, zip,
-			region, country, params, andOperator, start, end, sort);
+			region, country, params, andOperator, start, end, sorts);
 	}
 
 	@Override
@@ -1692,12 +1719,27 @@ public class OrganizationLocalServiceImpl
 			boolean andSearch, int start, int end, Sort sort)
 		throws PortalException {
 
+		Sort[] sorts = {sort};
+
+		return searchOrganizations(
+			companyId, parentOrganizationId, name, type, street, city, zip,
+			region, country, params, andSearch, start, end, sorts);
+	}
+
+	@Override
+	public BaseModelSearchResult<Organization> searchOrganizations(
+			long companyId, long parentOrganizationId, String name, String type,
+			String street, String city, String zip, String region,
+			String country, LinkedHashMap<String, Object> params,
+			boolean andSearch, int start, int end, Sort[] sorts)
+		throws PortalException {
+
 		Indexer<Organization> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			Organization.class);
 
 		SearchContext searchContext = buildSearchContext(
 			companyId, parentOrganizationId, name, type, street, city, zip,
-			region, country, params, andSearch, start, end, sort);
+			region, country, params, andSearch, start, end, sorts);
 
 		for (int i = 0; i < 10; i++) {
 			Hits hits = indexer.search(searchContext);
@@ -2088,7 +2130,7 @@ public class OrganizationLocalServiceImpl
 
 		SearchContext searchContext = buildSearchContext(
 			companyId, parentOrganizationId, name, type, street, city, zip,
-			region, country, params, andOperator, start, end, null);
+			region, country, params, andOperator, start, end, sorts);
 
 		Map<String, Serializable> attributes = searchContext.getAttributes();
 
@@ -2142,6 +2184,19 @@ public class OrganizationLocalServiceImpl
 		LinkedHashMap<String, Object> params, boolean andSearch, int start,
 		int end, Sort sort) {
 
+		Sort[] sorts = {sort};
+
+		return buildSearchContext(
+			companyId, parentOrganizationId, name, type, street, city, zip,
+			region, country, params, andSearch, start, end, sorts);
+	}
+
+	protected SearchContext buildSearchContext(
+		long companyId, long parentOrganizationId, String name, String type,
+		String street, String city, String zip, String region, String country,
+		LinkedHashMap<String, Object> params, boolean andSearch, int start,
+		int end, Sort[] sorts) {
+
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setAndSearch(andSearch);
@@ -2172,8 +2227,8 @@ public class OrganizationLocalServiceImpl
 			}
 		}
 
-		if (sort != null) {
-			searchContext.setSorts(sort);
+		if (sorts != null) {
+			searchContext.setSorts(sorts);
 		}
 
 		searchContext.setStart(start);
@@ -2243,6 +2298,30 @@ public class OrganizationLocalServiceImpl
 		}
 
 		return organizationIds;
+	}
+
+	protected Sort[] getSorts(OrderByComparator<Organization> obc) {
+		if (obc == null) {
+			return new Sort[0];
+		}
+
+		String[] orderByClauses = StringUtil.split(obc.getOrderBy());
+
+		String[] orderByFields = obc.getOrderByFields();
+
+		Sort[] sorts = new Sort[orderByFields.length];
+
+		for (int i = 0; i < orderByFields.length; i++) {
+			boolean reverse = orderByClauses[i].contains("DESC");
+
+			if (!Field.isSortableFieldName(orderByFields[i])) {
+				orderByFields[i] = Field.getSortableFieldName(orderByFields[i]);
+			}
+
+			sorts[i] = new Sort(orderByFields[i], reverse);
+		}
+
+		return sorts;
 	}
 
 	protected boolean isOrganizationGroup(long organizationId, long groupId) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalService.java
@@ -1150,7 +1150,21 @@ public interface OrganizationLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BaseModelSearchResult<Organization> searchOrganizations(
 			long companyId, long parentOrganizationId, String keywords,
+			LinkedHashMap<String, Object> params, int start, int end,
+			OrderByComparator<Organization> obc)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<Organization> searchOrganizations(
+			long companyId, long parentOrganizationId, String keywords,
 			LinkedHashMap<String, Object> params, int start, int end, Sort sort)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<Organization> searchOrganizations(
+			long companyId, long parentOrganizationId, String keywords,
+			LinkedHashMap<String, Object> params, int start, int end,
+			Sort[] sorts)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -1159,6 +1173,14 @@ public interface OrganizationLocalService
 			String street, String city, String zip, String region,
 			String country, LinkedHashMap<String, Object> params,
 			boolean andSearch, int start, int end, Sort sort)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BaseModelSearchResult<Organization> searchOrganizations(
+			long companyId, long parentOrganizationId, String name, String type,
+			String street, String city, String zip, String region,
+			String country, LinkedHashMap<String, Object> params,
+			boolean andSearch, int start, int end, Sort[] sorts)
 		throws PortalException;
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceUtil.java
@@ -1445,12 +1445,37 @@ public class OrganizationLocalServiceUtil {
 		<com.liferay.portal.kernel.model.Organization> searchOrganizations(
 				long companyId, long parentOrganizationId, String keywords,
 				java.util.LinkedHashMap<String, Object> params, int start,
+				int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.portal.kernel.model.Organization> obc)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchOrganizations(
+			companyId, parentOrganizationId, keywords, params, start, end, obc);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.Organization> searchOrganizations(
+				long companyId, long parentOrganizationId, String keywords,
+				java.util.LinkedHashMap<String, Object> params, int start,
 				int end, com.liferay.portal.kernel.search.Sort sort)
 			throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().searchOrganizations(
 			companyId, parentOrganizationId, keywords, params, start, end,
 			sort);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.Organization> searchOrganizations(
+				long companyId, long parentOrganizationId, String keywords,
+				java.util.LinkedHashMap<String, Object> params, int start,
+				int end, com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchOrganizations(
+			companyId, parentOrganizationId, keywords, params, start, end,
+			sorts);
 	}
 
 	public static com.liferay.portal.kernel.search.BaseModelSearchResult
@@ -1466,6 +1491,21 @@ public class OrganizationLocalServiceUtil {
 		return getService().searchOrganizations(
 			companyId, parentOrganizationId, name, type, street, city, zip,
 			region, country, params, andSearch, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.BaseModelSearchResult
+		<com.liferay.portal.kernel.model.Organization> searchOrganizations(
+				long companyId, long parentOrganizationId, String name,
+				String type, String street, String city, String zip,
+				String region, String country,
+				java.util.LinkedHashMap<String, Object> params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().searchOrganizations(
+			companyId, parentOrganizationId, name, type, street, city, zip,
+			region, country, params, andSearch, start, end, sorts);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceWrapper.java
@@ -1481,12 +1481,39 @@ public class OrganizationLocalServiceWrapper
 			searchOrganizations(
 				long companyId, long parentOrganizationId, String keywords,
 				java.util.LinkedHashMap<String, Object> params, int start,
+				int end,
+				com.liferay.portal.kernel.util.OrderByComparator<Organization>
+					obc)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _organizationLocalService.searchOrganizations(
+			companyId, parentOrganizationId, keywords, params, start, end, obc);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult<Organization>
+			searchOrganizations(
+				long companyId, long parentOrganizationId, String keywords,
+				java.util.LinkedHashMap<String, Object> params, int start,
 				int end, com.liferay.portal.kernel.search.Sort sort)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _organizationLocalService.searchOrganizations(
 			companyId, parentOrganizationId, keywords, params, start, end,
 			sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult<Organization>
+			searchOrganizations(
+				long companyId, long parentOrganizationId, String keywords,
+				java.util.LinkedHashMap<String, Object> params, int start,
+				int end, com.liferay.portal.kernel.search.Sort[] sorts)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _organizationLocalService.searchOrganizations(
+			companyId, parentOrganizationId, keywords, params, start, end,
+			sorts);
 	}
 
 	@Override
@@ -1503,6 +1530,22 @@ public class OrganizationLocalServiceWrapper
 		return _organizationLocalService.searchOrganizations(
 			companyId, parentOrganizationId, name, type, street, city, zip,
 			region, country, params, andSearch, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.BaseModelSearchResult<Organization>
+			searchOrganizations(
+				long companyId, long parentOrganizationId, String name,
+				String type, String street, String city, String zip,
+				String region, String country,
+				java.util.LinkedHashMap<String, Object> params,
+				boolean andSearch, int start, int end,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _organizationLocalService.searchOrganizations(
+			companyId, parentOrganizationId, name, type, street, city, zip,
+			region, country, params, andSearch, start, end, sorts);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 4.4.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-114717
https://issues.liferay.com/browse/LPP-37599

Hello @drewbrokke,

From what I understand you handle Users and Orgs review, if that's incorrect let me know.

On this ticket I've found that the Order By Type never has worked on Organizations. This is because "type" was never a sortable field within ES. Additionally since we expect many of the same type, type should be secondarily sorted by the the Organization name - as suggested [here](https://github.com/liferay/liferay-portal/blob/d6ef0f2011fd44e12e4300aeb91f74c2fa73085d/portal-kernel/src/com/liferay/portal/kernel/util/comparator/OrganizationTypeComparator.java#L26-L30). 

Commits 1660a8f, 31992cd, and 38a20c1 create the necessary infrastructure for the multiple sorts. This follows the same pattern used by Users in which the obc object is sent into a search() which can be track starting [here](https://github.com/liferay/liferay-portal/blob/266e24f395aa0c647bbd0f08e3f7350bec8a65f5/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewUsersManagementToolbarDisplayContext.java#L305-L308).

PS: I'm hoping to backport this to 7.1, let me know if that isn't a good idea.