### PR TITLE
[TS] LPS-114717 User and Organizations Search Filter Types not working 

### DIFF
--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/contributor/sort/OrganizationSortFieldNameTranslator.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/contributor/sort/OrganizationSortFieldNameTranslator.java
@@ -14,6 +14,9 @@
 
 package com.liferay.organizations.internal.search.contributor.sort;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.search.contributor.ContributorConstants;
 import com.liferay.portal.search.contributor.sort.SortFieldNameTranslator;
 
@@ -36,7 +39,8 @@ public class OrganizationSortFieldNameTranslator
 			return "name";
 		}
 		else if (orderByCol.equals("type")) {
-			return "type";
+			return Field.getSortableFieldName(
+				StringBundler.concat("type", StringPool.UNDERLINE, "String"));
 		}
 
 		return orderByCol;

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
@@ -64,6 +64,7 @@ public class OrganizationModelDocumentContributor
 				Field.ORGANIZATION_ID, organization.getOrganizationId());
 			document.addKeyword(Field.TREE_PATH, organization.buildTreePath());
 			document.addKeyword(Field.TYPE, organization.getType());
+			document.addTextSortable(Field.TYPE, organization.getType());
 			document.addTextSortable(
 				"nameTreePath", _buildNameTreePath(organization));
 			document.addKeyword(

--- a/modules/apps/organizations/organizations-test/build.gradle
+++ b/modules/apps/organizations/organizations-test/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
+	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-search:portal-search-api")
 	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:portal:portal-local-service-tree-test-util")

--- a/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/search/test/OrganizationIndexerIndexedFieldsTest.java
+++ b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/search/test/OrganizationIndexerIndexedFieldsTest.java
@@ -20,6 +20,7 @@ import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.model.ExpandoTable;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
@@ -238,6 +239,10 @@ public class OrganizationIndexerIndexedFieldsTest {
 			Field.TREE_PATH, organization.getTreePath()
 		).put(
 			Field.TYPE, organization.getType()
+		).put(
+			Field.getSortableFieldName(
+				StringBundler.concat("type", StringPool.UNDERLINE, "String")),
+			organization.getType()
 		).put(
 			Field.USER_ID, String.valueOf(organization.getUserId())
 		).put(

--- a/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/service/test/OrganizationLocalServiceTest.java
+++ b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/service/test/OrganizationLocalServiceTest.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.OrganizationParentException;
 import com.liferay.portal.kernel.model.Group;
@@ -27,9 +28,12 @@ import com.liferay.portal.kernel.model.ListTypeConstants;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
@@ -41,11 +45,15 @@ import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.After;
@@ -850,6 +858,71 @@ public class OrganizationLocalServiceTest {
 		Assert.assertEquals(hits.toString(), 0, hits.getLength());
 	}
 
+	@Test
+	public void testSearchOrganizationsByType() throws Exception {
+		String defaultType = "organization";
+		String orderByCol = "type";
+		String orderByType = "asc";
+
+		String orgType = "Test Org Type";
+
+		String configPid = _createOrganizationType(orgType);
+
+		List<Organization> organizations = new LinkedList<>();
+
+		try {
+			organizations.add(OrganizationTestUtil.addOrganization(orgType));
+
+			organizations.add(OrganizationTestUtil.addOrganization(orgType));
+
+			organizations.add(
+				OrganizationTestUtil.addOrganization(defaultType));
+
+			organizations.add(
+				OrganizationTestUtil.addOrganization(defaultType));
+
+			Organization org1 = organizations.get(0);
+
+			long companyId = org1.getCompanyId();
+
+			Sort sort = SortFactoryUtil.getSort(
+				Organization.class, orderByCol, orderByType);
+
+			BaseModelSearchResult<Organization> baseModelSearchResult =
+				OrganizationLocalServiceUtil.searchOrganizations(
+					companyId, 0, "", null, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, sort);
+
+			List<String> expectedResults = _getExpectedSortedOrganizationByType(
+				baseModelSearchResult.getBaseModels());
+
+			_assertTypeSortOrder(
+				expectedResults, baseModelSearchResult.getBaseModels());
+
+			orderByType = "desc";
+
+			sort = SortFactoryUtil.getSort(
+				Organization.class, orderByCol, orderByType);
+
+			baseModelSearchResult =
+				OrganizationLocalServiceUtil.searchOrganizations(
+					companyId, 0, "", null, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, sort);
+
+			Collections.reverse(expectedResults);
+
+			_assertTypeSortOrder(
+				expectedResults, baseModelSearchResult.getBaseModels());
+		}
+		finally {
+			for (Organization organization : organizations) {
+				OrganizationLocalServiceUtil.deleteOrganization(organization);
+			}
+
+			ConfigurationTestUtil.deleteConfiguration((String)configPid);
+		}
+	}
+
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
@@ -875,6 +948,56 @@ public class OrganizationLocalServiceTest {
 			parentOrganization.getOrganizationId(), keywords,
 			WorkflowConstants.STATUS_ANY, null, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
+	}
+
+	private void _assertTypeSortOrder(
+		List<String> expectedResults, List<Organization> actualResults) {
+
+		List<String> actualStringResults = new LinkedList<>();
+
+		for (Organization org : actualResults) {
+			actualStringResults.add(org.getType() + org.getName());
+		}
+
+		Assert.assertEquals(expectedResults, actualStringResults);
+	}
+
+	private String _createOrganizationType(String name) throws Exception {
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		String[] childTypes = {"organization", name};
+
+		properties.put("childrenTypes", childTypes);
+
+		properties.put("configuration.cleaner.ignore", "true");
+		properties.put("countryEnabled", true);
+		properties.put("countryRequired", false);
+		properties.put("name", name);
+		properties.put("rootable", true);
+		properties.put("service.bundleLocation", "?");
+		properties.put(
+			"service.factoryPid",
+			"com.liferay.organizations.internal.configuration." +
+				"OrganizationTypeConfiguration");
+
+		return ConfigurationTestUtil.createFactoryConfiguration(
+			"com.liferay.organizations.internal.configuration." +
+				"OrganizationTypeConfiguration",
+			properties);
+	}
+
+	private List<String> _getExpectedSortedOrganizationByType(
+		List<Organization> organizations) {
+
+		List<String> sortedTypeName = new LinkedList<>();
+
+		for (Organization org : organizations) {
+			sortedTypeName.add(org.getType() + org.getName());
+		}
+
+		Collections.sort(sortedTypeName, String.CASE_INSENSITIVE_ORDER);
+
+		return sortedTypeName;
 	}
 
 	private String _getTreePath(Organization[] organizations) {

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -47,6 +48,7 @@ import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.search.reindexer.ReindexerBridge;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -85,6 +87,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -2173,7 +2176,7 @@ public class OrganizationLocalServiceImpl
 		}
 
 		if (sort != null) {
-			searchContext.setSorts(sort);
+			searchContext.setSorts(_getSorts(sort));
 		}
 
 		searchContext.setStart(start);
@@ -2434,6 +2437,22 @@ public class OrganizationLocalServiceImpl
 		validate(
 			companyId, 0, parentOrganizationId, name, type, countryId,
 			statusId);
+	}
+
+	private Sort[] _getSorts(Sort sort) {
+		Sort[] sorts = {sort};
+
+		if (!Objects.equals(
+				Field.getSortableFieldName(Field.NAME), sort.getFieldName())) {
+
+			sorts = ArrayUtil.append(
+				sorts,
+				SortFactoryUtil.getSort(
+					Organization.class, Field.NAME,
+					sort.isReverse() ? "desc" : "asc"));
+		}
+
+		return sorts;
 	}
 
 	private static volatile OrganizationTypesSettings

--- a/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.test.util;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.EmailAddress;
 import com.liferay.portal.kernel.model.ListType;
@@ -83,6 +84,15 @@ public class OrganizationTestUtil {
 
 		return OrganizationLocalServiceUtil.addOrganization(
 			TestPropsValues.getUserId(), parentOrganizationId, name, site);
+	}
+
+	public static Organization addOrganization(String type) throws Exception {
+		return OrganizationLocalServiceUtil.addOrganization(
+			TestPropsValues.getUserId(),
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+			RandomTestUtil.randomString(), type, 0, 0,
+			ListTypeConstants.ORGANIZATION_STATUS_DEFAULT, StringPool.BLANK,
+			false, null);
 	}
 
 	public static OrgLabor addOrgLabor(Organization organization)

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0


### PR DESCRIPTION
[LPS-114717](https://issues.liferay.com/browse/LPS-114717)
Continued from https://github.com/joshuacords/liferay-portal/pull/80 and https://github.com/drewbrokke/liferay-portal/pull/1100
(Starting clean) 

Hello @drewbrokke,

I've finished my work on the test you requested. Because the organization tests don't initialize a clean company, other organizations may be present during tests so I couldn't use hardcoded values. There could be holes in the string compare method if someone/something adds a specific org types. I think the best way to address this type of issue would be to use a clean company for the org test but I don't have time to implement that for this component.

I also changed the field name from "type_sortable" to "type_String_sortable", this removes the need for [document.setSortableTextFields(_SORTABLE_TEXT_FIELDS);](https://github.com/joshuacords/liferay-portal/pull/80/files#diff-466da6eba65ef00773d9bb4dabc7a410R61), (and the version you sent indexed both type_sortable and type_String_sortable). More important is I found while trying to make a hotfix on 7.1, type_sortable is already being used by another component as a long which breaks the Elastic query, so we should just use the typified one and avoid the headache.

PS: I put the test changes in the first commits so you can run the test, see it fails, apply the fix and rerun to see it working.

> Hey Josh, for this one we can just write a test for the service layer search method to ensure that it returns results correctly sorted by type and name.

/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez