### PR TITLE
[TS] LPS-114717 

### DIFF
--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/contributor/sort/OrganizationSortFieldNameTranslator.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/contributor/sort/OrganizationSortFieldNameTranslator.java
@@ -14,6 +14,9 @@
 
 package com.liferay.organizations.internal.search.contributor.sort;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.search.contributor.ContributorConstants;
 import com.liferay.portal.search.contributor.sort.SortFieldNameTranslator;
 
@@ -36,7 +39,8 @@ public class OrganizationSortFieldNameTranslator
 			return "name";
 		}
 		else if (orderByCol.equals("type")) {
-			return "type";
+			return Field.getSortableFieldName(
+				StringBundler.concat("type", StringPool.UNDERLINE, "String"));
 		}
 
 		return orderByCol;

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
@@ -64,6 +64,7 @@ public class OrganizationModelDocumentContributor
 				Field.ORGANIZATION_ID, organization.getOrganizationId());
 			document.addKeyword(Field.TREE_PATH, organization.buildTreePath());
 			document.addKeyword(Field.TYPE, organization.getType());
+			document.addTextSortable(Field.TYPE, organization.getType());
 			document.addTextSortable(
 				"nameTreePath", _buildNameTreePath(organization));
 			document.addKeyword(

--- a/modules/apps/organizations/organizations-test/build.gradle
+++ b/modules/apps/organizations/organizations-test/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
+	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-search:portal-search-api")
 	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:portal:portal-local-service-tree-test-util")

--- a/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/search/test/OrganizationIndexerIndexedFieldsTest.java
+++ b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/search/test/OrganizationIndexerIndexedFieldsTest.java
@@ -20,6 +20,7 @@ import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.model.ExpandoTable;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
@@ -238,6 +239,10 @@ public class OrganizationIndexerIndexedFieldsTest {
 			Field.TREE_PATH, organization.getTreePath()
 		).put(
 			Field.TYPE, organization.getType()
+		).put(
+			Field.getSortableFieldName(
+				StringBundler.concat("type", StringPool.UNDERLINE, "String")),
+			organization.getType()
 		).put(
 			Field.USER_ID, String.valueOf(organization.getUserId())
 		).put(

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -47,6 +48,7 @@ import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.search.reindexer.ReindexerBridge;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -85,6 +87,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -2173,7 +2176,7 @@ public class OrganizationLocalServiceImpl
 		}
 
 		if (sort != null) {
-			searchContext.setSorts(sort);
+			searchContext.setSorts(_getSorts(sort));
 		}
 
 		searchContext.setStart(start);
@@ -2435,6 +2438,23 @@ public class OrganizationLocalServiceImpl
 			companyId, 0, parentOrganizationId, name, type, countryId,
 			statusId);
 	}
+
+	private Sort[] _getSorts(Sort sort) {
+		Sort[] sorts = {sort};
+
+		if (Objects.equals(_TYPE_FIELD_NAME, sort.getFieldName())) {
+			sorts = ArrayUtil.append(
+				sorts,
+				SortFactoryUtil.getSort(
+					Organization.class, Field.NAME,
+					sort.isReverse() ? "desc" : "asc"));
+		}
+
+		return sorts;
+	}
+
+	private static final String _TYPE_FIELD_NAME = Field.getSortableFieldName(
+		StringBundler.concat(Field.TYPE, StringPool.UNDERLINE, "String"));
 
 	private static volatile OrganizationTypesSettings
 		_organizationTypesSettings =

--- a/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.test.util;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.EmailAddress;
 import com.liferay.portal.kernel.model.ListType;
@@ -83,6 +84,15 @@ public class OrganizationTestUtil {
 
 		return OrganizationLocalServiceUtil.addOrganization(
 			TestPropsValues.getUserId(), parentOrganizationId, name, site);
+	}
+
+	public static Organization addOrganization(String type) throws Exception {
+		return OrganizationLocalServiceUtil.addOrganization(
+			TestPropsValues.getUserId(),
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+			RandomTestUtil.randomString(), type, 0, 0,
+			ListTypeConstants.ORGANIZATION_STATUS_DEFAULT, StringPool.BLANK,
+			false, null);
 	}
 
 	public static OrgLabor addOrgLabor(Organization organization)

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0


### PR DESCRIPTION
[LPS-114717](https://issues.liferay.com/browse/LPS-114717)
Continued from https://github.com/joshuacords/liferay-portal/pull/81

Tests successful: 
[**ci:test:stable - 20 out of 20 jobs passed
ci:test:relevant - 53 out of 53 jobs passed in 1 hour 38 minutes**](https://github.com/joshuacords/liferay-portal/pull/81)

Hello @drewbrokke,

I've finished my work on the test you requested. I used the best method I could come up with to sort, it uses the OrderByComparator, but the OBC for names distinguishes between upper and lower case, where search everywhere does not. Because I didn't want to change the OBC for Type to ignore lowercase, I had add the lowercase method you see.

I also changed the field name from "type_sortable" to "type_String_sortable", this removes the need for [document.setSortableTextFields(_SORTABLE_TEXT_FIELDS);](https://github.com/joshuacords/liferay-portal/pull/80/files#diff-466da6eba65ef00773d9bb4dabc7a410R61), (and the version you sent indexed both type_sortable and type_String_sortable). More important is I found while trying to make a hotfix on 7.1, type_sortable is already being used by another component as a long which breaks the Elastic query, so we should just use the typified one and avoid the headache.

I needed to change the [_getSorts](https://github.com/drewbrokke/liferay-portal/compare/master...joshuacords:JCords-LPS-114717-2?expand=1#diff-34826a1909c5f8a0985550450f799d5eR2442) to be specific for the type field. This is because other processes, such as [this test](https://github.com/liferay/liferay-portal/blob/b6468bc512059b579a40e6dfc50f8322d654688b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/service/test/OrganizationLocalServiceWhenSearchingOrganizationsTreeTest.java#L255-L260), use other sorts and would become flaky tests without this change. 

PS: I put the test changes in the first commits so you can run the test, see it fails, apply the fix and rerun to see it working.

> Hey Josh, for this one we can just write a test for the service layer search method to ensure that it returns results correctly sorted by type and name.
