### PR TITLE
[TS] LPS-114640

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -285,7 +285,7 @@
 				return '<%= themeDisplay.getUserId() %>';
 			},
 			getUserName: function() {
-				return '<%= themeDisplay.isSignedIn() ? HtmlUtil.escapeJS(UnicodeFormatter.toString(user.getFullName())) : StringPool.BLANK %>';
+				return '<%= themeDisplay.isSignedIn() ? UnicodeFormatter.toString(user.getFullName()) : StringPool.BLANK %>';
 			},
 			isAddSessionIdToURL: function() {
 				return <%= themeDisplay.isAddSessionIdToURL() %>;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-114640

From @holatuwol:

> The issue is that `UnicodeFormatter` is already JS-safe, so when we decide to wrap it with another `HtmlUtil.escapeJS`, that causes it to change every `\u` into `\\u`, which is wrong.

CC @tototrinh