### PR TITLE
[TS] LPS-116382

### DIFF
--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserServiceWhenCompanySecurityStrangersWithMXDisabledTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserServiceWhenCompanySecurityStrangersWithMXDisabledTest.java
@@ -89,16 +89,7 @@ public class UserServiceWhenCompanySecurityStrangersWithMXDisabledTest {
 		String name = PrincipalThreadLocal.getName();
 
 		try {
-			_user = UserTestUtil.addUser(false);
-
-			PrincipalThreadLocal.setName(_user.getUserId());
-
-			String emailAddress =
-				"UserServiceTest." + RandomTestUtil.nextLong() + "@liferay.com";
-
-			_userService.updateEmailAddress(
-				_user.getUserId(), _user.getPassword(), emailAddress,
-				emailAddress, new ServiceContext());
+			_updateEmailAddress();
 		}
 		finally {
 			PrincipalThreadLocal.setName(name);
@@ -109,16 +100,75 @@ public class UserServiceWhenCompanySecurityStrangersWithMXDisabledTest {
 	public void testShouldNotUpdateUser() throws Exception {
 		String name = PrincipalThreadLocal.getName();
 
-		_user = UserTestUtil.addUser(false);
-
 		try {
-			PrincipalThreadLocal.setName(_user.getUserId());
-
-			UserTestUtil.updateUser(_user);
+			_updateUser();
 		}
 		finally {
 			PrincipalThreadLocal.setName(name);
 		}
+	}
+
+	@Test
+	public void testShouldUpdateEmailAddress() throws Exception {
+		String name = PrincipalThreadLocal.getName();
+
+		String companySecurityStrangers = PropsUtil.get(
+			PropsKeys.COMPANY_SECURITY_STRANGERS);
+
+		PropsUtil.set(
+			PropsKeys.COMPANY_SECURITY_STRANGERS, Boolean.FALSE.toString());
+
+		try {
+			_updateEmailAddress();
+		}
+		finally {
+			PrincipalThreadLocal.setName(name);
+
+			PropsUtil.set(
+				PropsKeys.COMPANY_SECURITY_STRANGERS, companySecurityStrangers);
+		}
+	}
+
+	@Test
+	public void testShouldUpdateUser() throws Exception {
+		String name = PrincipalThreadLocal.getName();
+
+		String companySecurityStrangers = PropsUtil.get(
+			PropsKeys.COMPANY_SECURITY_STRANGERS);
+
+		PropsUtil.set(
+			PropsKeys.COMPANY_SECURITY_STRANGERS, Boolean.FALSE.toString());
+
+		try {
+			_updateUser();
+		}
+		finally {
+			PrincipalThreadLocal.setName(name);
+
+			PropsUtil.set(
+				PropsKeys.COMPANY_SECURITY_STRANGERS, companySecurityStrangers);
+		}
+	}
+
+	private void _updateEmailAddress() throws Exception {
+		_user = UserTestUtil.addUser(false);
+
+		PrincipalThreadLocal.setName(_user.getUserId());
+
+		String emailAddress =
+			"UserServiceTest." + RandomTestUtil.nextLong() + "@liferay.com";
+
+		_userService.updateEmailAddress(
+			_user.getUserId(), _user.getPassword(), emailAddress, emailAddress,
+			new ServiceContext());
+	}
+
+	private void _updateUser() throws Exception {
+		_user = UserTestUtil.addUser(false);
+
+		PrincipalThreadLocal.setName(_user.getUserId());
+
+		UserTestUtil.updateUser(_user);
 	}
 
 	private static String _companySecurityStrangersWithMX;

--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -2701,7 +2701,7 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 			Company company = companyPersistence.findByPrimaryKey(
 				user.getCompanyId());
 
-			if (!company.isStrangersWithMx()) {
+			if (company.isStrangers() && !company.isStrangersWithMx()) {
 				throw new UserEmailAddressException.MustNotUseCompanyMx(
 					emailAddress);
 			}


### PR DESCRIPTION
Hi @drewbrokke,

This change makes the validation logic mimic other areas of the portal (https://github.com/liferay/liferay-portal/blob/master/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/struts/FacebookConnectStrutsAction.java#L456-L473) as well as the description for the property `company.security.strangers.with.mx`:

```
# Set this to true if strangers can create accounts with email addresses
# that match the company mail suffix. This property is not used unless
# "company.security.strangers" is also set to true.
```

Please let me know if you have any questions or concerns.