### PR TITLE
[TS] LPS-116317

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/OrganizationScreenNavigationDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/OrganizationScreenNavigationDisplayContext.java
@@ -29,6 +29,10 @@ public class OrganizationScreenNavigationDisplayContext {
 		return _editOrganizationActionURL;
 	}
 
+	public String getEditOrganizationRenderURL() {
+		return _editOrganizationRenderURL;
+	}
+
 	public String getFormLabel() {
 		return _formLabel;
 	}
@@ -65,6 +69,10 @@ public class OrganizationScreenNavigationDisplayContext {
 		_editOrganizationActionURL = editOrganizationActionURL;
 	}
 
+	public void setEditOrganizationRenderURL(String editOrganizationRenderURL) {
+		_editOrganizationRenderURL = editOrganizationRenderURL;
+	}
+
 	public void setFormLabel(String formLabel) {
 		_formLabel = formLabel;
 	}
@@ -91,6 +99,7 @@ public class OrganizationScreenNavigationDisplayContext {
 
 	private String _backURL;
 	private String _editOrganizationActionURL;
+	private String _editOrganizationRenderURL;
 	private String _formLabel;
 	private String _jspPath;
 	private Organization _organization;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/OrganizationScreenNavigationEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/OrganizationScreenNavigationEntry.java
@@ -163,6 +163,9 @@ public class OrganizationScreenNavigationEntry
 		editOrganizationRenderURL.setParameter(
 			"screenNavigationEntryKey", _entryKey);
 
+		organizationScreenNavigationDisplayContext.setEditOrganizationRenderURL(
+			editOrganizationRenderURL.toString());
+
 		editOrganizationActionURL.setParameter(
 			"redirect", editOrganizationRenderURL.toString());
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_navigation.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_navigation.jsp
@@ -21,6 +21,8 @@ OrganizationScreenNavigationDisplayContext organizationScreenNavigationDisplayCo
 %>
 
 <aui:form action="<%= organizationScreenNavigationDisplayContext.getEditOrganizationActionURL() %>" cssClass="portlet-users-admin-edit-organization" method="post" name="fm">
+	<aui:input name="redirect" type="hidden" value="<%= organizationScreenNavigationDisplayContext.getEditOrganizationRenderURL() %>" />
+
 	<clay:sheet>
 		<c:if test="<%= organizationScreenNavigationDisplayContext.isShowTitle() %>">
 			<clay:sheet-header>


### PR DESCRIPTION
From @kevhlee:

https://issues.liferay.com/browse/LPS-116317

> The issue is that a redirect URL needs to be passed to the edit page's form. Failure to do this results in the back arrow and cancel buttons lacking back URLs and thus no longer functioning. To resolve this issue, I record the render URL used during the creation of the organizationScreenNavigationDisplayContext and pass it as input to the edit page's form.
> 
> This is a new pull request based on work mentioned here: https://github.com/drewbrokke/liferay-portal/pull/1120.
> 
> With regards,
> Kevin

CC @wanderlast