### PR TITLE
LPS-109571 Use raw query string instead

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -616,7 +616,7 @@ public class HttpImpl implements Http {
 			return StringPool.BLANK;
 		}
 
-		String queryString = uri.getQuery();
+		String queryString = uri.getRawQuery();
 
 		if (queryString == null) {
 			return StringPool.BLANK;


### PR DESCRIPTION
From @kevhlee:

> Relevant Tickets:
> - [LPS-107404](https://issues.liferay.com/browse/LPS-107404)
> - [LPS-109571](https://issues.liferay.com/browse/LPS-109571)
> 
> This pull request fixes a regression caused by [LPS-107404](https://issues.liferay.com/browse/LPS-107404). Specifically, the issue is caused by this [change](https://github.com/liferay/liferay-portal/commit/4ee33c1e04a03b5c61417adf4921986d0b7d694d#diff-0c0ec4315d8e69a7aaa1a4a8e9114881R630-R638) made by commit <https://github.com/liferay/liferay-portal/commit/4ee33c1e04a03b5c61417adf4921986d0b7d694d>. The raw query string must be used so that URL escaping is performed correctly and query parameters like `doAsUserId` are not manipulated.

CC @wanderlast