### PR TITLE
LPS-116387 Add workflow support for account roles

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/src/main/java/com/liferay/portal/workflow/kaleo/runtime/util/RoleUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/src/main/java/com/liferay/portal/workflow/kaleo/runtime/util/RoleUtil.java
@@ -80,7 +80,10 @@ public class RoleUtil {
 	}
 
 	public static int getRoleType(String roleType) {
-		if (roleType.equals(RoleConstants.TYPE_DEPOT_LABEL)) {
+		if (roleType.equals(RoleConstants.TYPE_ACCOUNT_LABEL)) {
+			return RoleConstants.TYPE_ACCOUNT;
+		}
+		else if (roleType.equals(RoleConstants.TYPE_DEPOT_LABEL)) {
 			return RoleConstants.TYPE_DEPOT;
 		}
 		else if (roleType.equals(RoleConstants.TYPE_ORGANIZATION_LABEL)) {

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/build.gradle
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly group: "org.springframework", name: "spring-context", version: "5.2.2.RELEASE"
+	compileOnly project(":apps:account:account-api")
 	compileOnly project(":apps:portal-rules-engine:portal-rules-engine-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/assignment/GroupAwareRoleTaskAssignmentSelector.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/assignment/GroupAwareRoleTaskAssignmentSelector.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.workflow.kaleo.runtime.internal.assignment;
 
+import com.liferay.account.model.AccountEntry;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.workflow.kaleo.KaleoTaskAssignmentFactory;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
@@ -33,6 +35,7 @@ import com.liferay.portal.workflow.kaleo.runtime.assignment.TaskAssignmentSelect
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -154,8 +157,14 @@ public class GroupAwareRoleTaskAssignmentSelector
 	protected boolean isValidAssignment(Group group, Role role)
 		throws PortalException {
 
-		if ((group != null) && (group.getType() == GroupConstants.TYPE_DEPOT) &&
-			(role.getType() == RoleConstants.TYPE_DEPOT)) {
+		if ((group != null) && _isAccountEntryGroup(group) &&
+			(role.getType() == RoleConstants.TYPE_ACCOUNT)) {
+
+			return true;
+		}
+		else if ((group != null) &&
+				 (group.getType() == GroupConstants.TYPE_DEPOT) &&
+				 (role.getType() == RoleConstants.TYPE_DEPOT)) {
 
 			return true;
 		}
@@ -176,6 +185,17 @@ public class GroupAwareRoleTaskAssignmentSelector
 		return false;
 	}
 
+	private boolean _isAccountEntryGroup(Group group) {
+		if (Objects.equals(
+				_portal.getClassNameId(AccountEntry.class),
+				group.getClassNameId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	@Reference
 	private GroupLocalService _groupLocalService;
 
@@ -184,6 +204,9 @@ public class GroupAwareRoleTaskAssignmentSelector
 
 	@Reference
 	private OrganizationLocalService _organizationLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/recipient/RoleNotificationRecipientBuilder.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/recipient/RoleNotificationRecipientBuilder.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.workflow.kaleo.runtime.internal.notification.recipient;
 
+import com.liferay.account.model.AccountEntry;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.workflow.kaleo.definition.NotificationReceptionType;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
@@ -41,6 +43,7 @@ import com.liferay.portal.workflow.kaleo.runtime.notification.recipient.Notifica
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -207,8 +210,14 @@ public class RoleNotificationRecipientBuilder
 	protected boolean isValidGroup(Group group, Role role)
 		throws PortalException {
 
-		if ((group != null) && (group.getType() == GroupConstants.TYPE_DEPOT) &&
-			(role.getType() == RoleConstants.TYPE_DEPOT)) {
+		if ((group != null) && _isAccountEntryGroup(group) &&
+			(role.getType() == RoleConstants.TYPE_ACCOUNT)) {
+
+			return true;
+		}
+		else if ((group != null) &&
+				 (group.getType() == GroupConstants.TYPE_DEPOT) &&
+				 (role.getType() == RoleConstants.TYPE_DEPOT)) {
 
 			return true;
 		}
@@ -226,11 +235,25 @@ public class RoleNotificationRecipientBuilder
 		return false;
 	}
 
+	private boolean _isAccountEntryGroup(Group group) {
+		if (Objects.equals(
+				_portal.getClassNameId(AccountEntry.class),
+				group.getClassNameId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private OrganizationLocalService _organizationLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private RoleLocalService _roleLocalService;


### PR DESCRIPTION
Hey Drew,

This changes adds the account role to the workflow so that workflow tasks can be scoped to accounts and notifies users with the account roles. However, I don't like how we have to add account-api dependency in the workflow module. Any ideas on an alternative approach?