### PR TITLE
[TS] LPS-118342 Prevent the passwordModifiedDate being later than the session creationTime

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/LoginPostAction.java
+++ b/portal-impl/src/com/liferay/portal/events/LoginPostAction.java
@@ -149,6 +149,12 @@ public class LoginPostAction extends Action {
 		Date now = new Date();
 
 		if (user.getPasswordModifiedDate() == null) {
+			HttpSession session = httpServletRequest.getSession(false);
+
+			if (session != null) {
+				now = new Date(session.getCreationTime());
+			}
+
 			user.setPasswordModifiedDate(now);
 
 			UserLocalServiceUtil.updateUser(user);


### PR DESCRIPTION
Hi Drew,

I found that the issue occurs because after a succesful login the execution rans onto the PasswordModifiedFilter. In this, the _isPasswordModified returns true, after which the user is logged out. This happens because the passwordModifiedDate is updated after the session is created. That's what I try to avoid with this fix.

Could you please review my changes?

Thank you,
Laci