### PR TITLE
LPS-119517 Remove account-api dependency from users-admin-web

### DIFF
--- a/modules/apps/account/app.bnd
+++ b/modules/apps/account/app.bnd
@@ -1,15 +1,15 @@
 Liferay-Releng-App-Description:
 Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Account
-Liferay-Releng-Bundle: true
+Liferay-Releng-Bundle: false
 Liferay-Releng-Category: Utility
 Liferay-Releng-Demo-Url:
 Liferay-Releng-Deprecated: false
-Liferay-Releng-Fix-Delivery-Method: core
+Liferay-Releng-Fix-Delivery-Method:
 Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
-Liferay-Releng-Portal-Required: true
+Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: true
-Liferay-Releng-Suite: foundation
+Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/constants/UsersAdminWebKeys.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/constants/UsersAdminWebKeys.java
@@ -23,11 +23,12 @@ public class UsersAdminWebKeys {
 
 	public static final String EDITABLE = "EDITABLE";
 
-	public static final String FILTER_CONTRIBUTORS = "FILTER_CONTRIBUTORS";
-
 	public static final String FORM_LABEL = "FORM_LABEL";
 
 	public static final String JSP_PATH = "JSP_PATH";
+
+	public static final String MANAGEMENT_TOOLBAR_FILTER_CONTRIBUTORS =
+		"MANAGEMENT_TOOLBAR_FILTER_CONTRIBUTORS";
 
 	public static final String ORGANIZATION_SCREEN_NAVIGATION_DISPLAY_CONTEXT =
 		"ORGANIZATION_SCREEN_NAVIGATION_DISPLAY_CONTEXT";

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewFlatUsersDisplayContextFactory.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewFlatUsersDisplayContextFactory.java
@@ -136,7 +136,7 @@ public class ViewFlatUsersDisplayContextFactory {
 
 		return Optional.ofNullable(
 			(FilterContributor[])httpServletRequest.getAttribute(
-				UsersAdminWebKeys.FILTER_CONTRIBUTORS));
+				UsersAdminWebKeys.MANAGEMENT_TOOLBAR_FILTER_CONTRIBUTORS));
 	}
 
 	protected static boolean isShowDeleteButton(

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -52,7 +52,7 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
 		renderRequest.setAttribute(
-			UsersAdminWebKeys.FILTER_CONTRIBUTORS,
+			UsersAdminWebKeys.MANAGEMENT_TOOLBAR_FILTER_CONTRIBUTORS,
 			_filterContributorTracker.getFilterContributors(
 				UsersAdminManagementToolbarKeys.VIEW_FLAT_USERS));
 		renderRequest.setAttribute(


### PR DESCRIPTION
This is an update for [LPS-119517](https://issues.liferay.com/browse/LPS-119517).
This is an update for [LPS-118750](https://issues.liferay.com/browse/LPS-118750).

Hey @brianchandotcom, this renames the constant as we discussed. It also excludes the `account` modules from the release build.

/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez @jpince