### PR TITLE
LPS-116387 Add workflow support for account roles

### DIFF
--- a/definitions/liferay-workflow-definition_7_4_0.xsd
+++ b/definitions/liferay-workflow-definition_7_4_0.xsd
@@ -451,6 +451,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="role-type">
 		<xs:restriction base="xs:string">
+			<xs:enumeration value="account" />
 			<xs:enumeration value="depot" />
 			<xs:enumeration value="organization" />
 			<xs:enumeration value="regular" />

--- a/modules/apps/account/account-service/build.gradle
+++ b/modules/apps/account/account-service/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-runtime-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/portal/workflow/kaleo/runtime/util/validator/AccountRoleGroupAwareRoleValidator.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/portal/workflow/kaleo/runtime/util/validator/AccountRoleGroupAwareRoleValidator.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.portal.workflow.kaleo.runtime.util.validator;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.workflow.kaleo.runtime.util.validator.GroupAwareRoleValidator;
+
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Component(immediate = true, service = GroupAwareRoleValidator.class)
+public class AccountRoleGroupAwareRoleValidator
+	implements GroupAwareRoleValidator {
+
+	public boolean isValidGroup(Group group, Role role) throws PortalException {
+		if ((group != null) && _isAccountEntryGroup(group) &&
+			(role.getType() == RoleConstants.TYPE_ACCOUNT)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isAccountEntryGroup(Group group) {
+		if (Objects.equals(
+				_portal.getClassNameId(AccountEntry.class),
+				group.getClassNameId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/build.gradle
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/build.gradle
@@ -3,9 +3,11 @@ dependencies {
 	compileOnly group: "com.sun.mail", name: "javax.mail", version: "1.6.2"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:portal-rules-engine:portal-rules-engine-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-definition-api")
+	compileOnly project(":apps:roles:roles-admin-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/resources/com/liferay/portal/workflow/kaleo/dependencies/single-approver-definition.xml
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/resources/com/liferay/portal/workflow/kaleo/dependencies/single-approver-definition.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 
 <workflow-definition
-	xmlns="urn:liferay.com:liferay-workflow_7.1.0"
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.1.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_1_0.xsd"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
 >
 	<name>Single Approver</name>
 	<description>A single approver can approve a workflow content.</description>
@@ -118,6 +118,14 @@
 		</actions>
 		<assignments>
 			<roles>
+				<role>
+					<role-type>account</role-type>
+					<name>Account Administrator</name>
+				</role>
+				<role>
+					<role-type>organization</role-type>
+					<name>Account Manager</name>
+				</role>
 				<role>
 					<role-type>organization</role-type>
 					<name>Organization Administrator</name>

--- a/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributor.java
+++ b/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributor.java
@@ -15,6 +15,7 @@
 package com.liferay.roles.admin.role.type.contributor;
 
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.util.Locale;
@@ -108,6 +109,10 @@ public interface RoleTypeContributor {
 	 * @return an integer that represents the role type
 	 */
 	public int getType();
+
+	public default String getTypeLabel() {
+		return RoleConstants.getTypeLabel(getType());
+	}
 
 	/**
 	 * Returns <code>true</code> if users are allowed to assign members to the


### PR DESCRIPTION
Hey Drew,

Can you review my changes for adding the workflow support for account roles? In order to fully support account roles in the workflow, it requires modification to the workflow definition schema. We won't be able to create the new schema file until 7.3 is released so we'll need to hold off on sending the changes. Yet, I'd like to get your review first to make sure the changes are good so we can send it as soon as 7.3 is released. Thanks\!