### PR TITLE
LPS-124638

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -1167,7 +1167,8 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				params2.remove("usersGroups");
 
 				if (PropsValues.ORGANIZATIONS_MEMBERSHIP_STRICT) {
-					params2.put("usersOrgs", organizationIds);
+					params2.put(
+						"usersOrgs", organizationIds.toArray(new Long[0]));
 				}
 				else {
 					Map<Serializable, Organization> organizations =


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-124638

From @holatuwol: 

> Issue occurs because the code block in `getWhere` only checks for `Long` and `Long[]`. Chose this solution because at around line 1248, there is a similar code block that does the array conversion.