### PR TITLE
LPS-123413 NullPointerException is thrown when deleting user

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewFlatUsersDisplayContextFactory.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewFlatUsersDisplayContextFactory.java
@@ -37,6 +37,7 @@ import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 import com.liferay.users.admin.management.toolbar.FilterContributor;
 import com.liferay.users.admin.web.internal.constants.UsersAdminWebKeys;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
@@ -220,16 +221,36 @@ public class ViewFlatUsersDisplayContextFactory {
 			}
 		}
 
-		int total = UserLocalServiceUtil.searchCount(
-			themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-			searchTerms.getStatus(), params);
+		List<User> results = null;
 
-		userSearch.setTotal(total);
+		for (int i = 0; i <= _RETRY_ATTEMPTS; i++) {
+			int total = UserLocalServiceUtil.searchCount(
+				themeDisplay.getCompanyId(), searchTerms.getKeywords(),
+				searchTerms.getStatus(), params);
 
-		List<User> results = UserLocalServiceUtil.search(
-			themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-			searchTerms.getStatus(), params, userSearch.getStart(),
-			userSearch.getEnd(), userSearch.getOrderByComparator());
+			userSearch.setTotal(total);
+
+			results = UserLocalServiceUtil.search(
+				themeDisplay.getCompanyId(), searchTerms.getKeywords(),
+				searchTerms.getStatus(), params, userSearch.getStart(),
+				userSearch.getEnd(), userSearch.getOrderByComparator());
+
+			if (results != null) {
+				break;
+			}
+
+			try {
+				if (i < _RETRY_ATTEMPTS) {
+					Thread.sleep(_RETRY_INTERVAL);
+				}
+			}
+			catch (InterruptedException interruptedException) {
+			}
+		}
+
+		if (results == null) {
+			results = new ArrayList<>();
+		}
 
 		userSearch.setResults(results);
 
@@ -246,5 +267,9 @@ public class ViewFlatUsersDisplayContextFactory {
 
 		return userSearch;
 	}
+
+	private static final int _RETRY_ATTEMPTS = 3;
+
+	private static final int _RETRY_INTERVAL = 500;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewFlatUsersDisplayContextFactory.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewFlatUsersDisplayContextFactory.java
@@ -236,7 +236,19 @@ public class ViewFlatUsersDisplayContextFactory {
 				userSearch.getEnd(), userSearch.getOrderByComparator());
 
 			if (results != null) {
-				break;
+				boolean staleIndex = false;
+
+				for (User user : results) {
+					if (user.getStatus() != searchTerms.getStatus()) {
+						staleIndex = true;
+
+						break;
+					}
+				}
+
+				if (!staleIndex) {
+					break;
+				}
 			}
 
 			try {


### PR DESCRIPTION
[LPS-123413](https://issues.liferay.com/browse/LPS-123413)
Hi Drew,

I hope you can review my changes.

**Issue:**
When administering users on "Users and Organizations" page the following issues may occur:

- When deleting user(s), NPE may be thrown and no users are displayed.
- When activating/inactivating users, the activated/inactivated users doesn't disappear from the list.

The above issues occur because the re-rendering of the page happens earlier than the update of the affected search index documents.

**Note:** Reproduction is easier with remote ES and HSQL, but I was able to reproduce with embedded ES and MySQL as well.

**Solution:**
In case of stale index state the search is repeated with 500 ms delay, maximum 3 times to avoid too long page render times.

Please let me know if you have any questions or concerns.

Thank you,
Istvan