### PR TITLE
LPS-121921 Migrate v2 usages in user-associated-data-web

### DIFF
--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
@@ -60,10 +60,9 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 				}
 				%>
 
-				<clay:management-toolbar-v2
+				<clay:management-toolbar
 					disabled="<%= disableManagementBar %>"
 					itemsTotal="<%= uadApplicationExportDisplayList.size() %>"
-					namespace="<%= liferayPortletResponse.getNamespace() %>"
 					searchContainerId="uadApplicationExportDisplay"
 					selectable="<%= true %>"
 					showSearch="<%= false %>"

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
@@ -36,8 +36,8 @@ if (parentContainerId > 0) {
 long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new ViewUADEntitiesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, viewUADEntitiesDisplay) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new ViewUADEntitiesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, viewUADEntitiesDisplay) %>"
 />
 
 <aui:form method="post" name="viewUADEntitiesFm">

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_export_processes.jsp
@@ -45,8 +45,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	%>'
 />
 
-<clay:management-toolbar-v2
-	displayContext="<%= uadExportProcessManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= uadExportProcessManagementToolbarDisplayContext %>"
 />
 
 <aui:form cssClass="container-fluid container-fluid-max-xl">


### PR DESCRIPTION
Hey Drew, I'm sending you a PR after it's been reviewed by the Frontend Infra at https://github.com/liferay-frontend/liferay-portal/pull/877. It is updating the Management Toolbar usages from v2 to the current Clay variant using the updated Tag.