### PR TITLE
LPS-128992 Migrate v2 usages in marketplace/marketplace-app-manager-web

### DIFF
--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,7 +24,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "app-man
 
 <portlet:renderURL var="viewURL" />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= viewAppsManagerManagementToolbarDisplayContext.getClearResultsURL() %>"
 	filterDropdownItems="<%= viewAppsManagerManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	filterLabelItems="<%= viewAppsManagerManagementToolbarDisplayContext.getFilterLabelItems() %>"

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_module.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_module.jsp
@@ -63,7 +63,7 @@ else {
 	navigationItems="<%= appManagerDisplayContext.getModuleNavigationItems() %>"
 />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	searchActionURL="<%= viewModuleManagementToolbarDisplayContext.getSearchActionURL() %>"
 	searchContainerId="plugins"
 	searchFormName="searchFm"

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_modules.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_modules.jsp
@@ -42,7 +42,7 @@ MarketplaceAppManagerUtil.addPortletBreadcrumbEntry(appDisplay, request, renderR
 	<portlet:param name="app" value="<%= app %>" />
 </portlet:renderURL>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	filterDropdownItems="<%= viewModulesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	searchActionURL="<%= viewModulesManagementToolbarDisplayContext.getSearchActionURL() %>"
 	searchContainerId="bundles"

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_search_results.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_search_results.jsp
@@ -38,7 +38,7 @@ AppManagerSearchResultsManagementToolbarDisplayContext appManagerSearchResultsMa
 SearchContainer<Object> searchContainer = appManagerSearchResultsManagementToolbarDisplayContext.getSearchContainer();
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= redirect %>"
 	itemsTotal="<%= searchContainer.getTotal() %>"
 	searchActionURL="<%= appManagerSearchResultsManagementToolbarDisplayContext.getSearchActionURL() %>"


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Search for installed applications and modules should work as expected.

![](https://user-images.githubusercontent.com/5572/110763679-6f3b0480-8252-11eb-91f3-a286cff58bf7.gif)

**Test plan**
- From the mega menu, select the **Control Panel** tab
- Navigate to **System** > **App Manager**
- Make sure you can search for installed applications and modules