### PR TITLE
[TS] LPS-130651

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.search.spi.model.permission.contributor;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroupRoleTable;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.ExistsFilter;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.search.spi.model.permission.SearchPermissionFilterContributor;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eric Yan
+ */
+@Component(immediate = true, service = SearchPermissionFilterContributor.class)
+public class UserSearchPermissionFilterContributor
+	implements SearchPermissionFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, long companyId, long[] groupIds,
+		long userId, PermissionChecker permissionChecker, String className) {
+
+		if (!className.equals(User.class.getName())) {
+			return;
+		}
+
+		if (_hasPermissionToManageAccountEntryUsers(companyId, userId)) {
+			_addAllAccountEntryUsersFilter(booleanFilter);
+		}
+	}
+
+	private void _addAllAccountEntryUsersFilter(BooleanFilter booleanFilter) {
+		booleanFilter.add(new ExistsFilter("accountEntryIds"));
+	}
+
+	private boolean _hasPermissionToManageAccountEntryUsers(
+		long companyId, long userId) {
+
+		List<Role> roles = _roleLocalService.getResourceRoles(
+			companyId, AccountEntry.class.getName(),
+			ResourceConstants.SCOPE_GROUP_TEMPLATE, "0",
+			ActionKeys.MANAGE_USERS);
+
+		if (ListUtil.isNotEmpty(roles)) {
+			DSLQuery dslQuery = DSLQueryFactoryUtil.count(
+			).from(
+				UserGroupRoleTable.INSTANCE
+			).where(
+				UserGroupRoleTable.INSTANCE.companyId.eq(
+					companyId
+				).and(
+					UserGroupRoleTable.INSTANCE.userId.eq(userId)
+				).and(
+					UserGroupRoleTable.INSTANCE.roleId.in(
+						ListUtil.toArray(roles, Role.ROLE_ID_ACCESSOR))
+				)
+			);
+
+			long matchingUserGroupRolesCount =
+				_userGroupRoleLocalService.dslQuery(dslQuery);
+
+			if (matchingUserGroupRolesCount > 0) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
+
+}

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
@@ -397,6 +398,8 @@ public class UserLocalServiceTest {
 
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(groupAdminUser));
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		try {
 			LinkedHashMap<String, Object> userParams =
@@ -421,6 +424,7 @@ public class UserLocalServiceTest {
 		}
 		finally {
 			PermissionThreadLocal.setPermissionChecker(oldPermissionChecker);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
@@ -25,6 +25,8 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.search.spi.model.permission.SearchPermissionFilterContributor;
 
 import org.osgi.service.component.annotations.Component;
@@ -50,7 +52,9 @@ public class UserSearchPermissionFilterContributor
 			return;
 		}
 
-		_addAllUsersFilter(booleanFilter, companyId);
+		if (_isGroupAdmin(permissionChecker)) {
+			_addAllUsersFilter(booleanFilter, companyId);
+		}
 	}
 
 	private void _addAllUsersFilter(
@@ -71,6 +75,17 @@ public class UserSearchPermissionFilterContributor
 				"Unable to get the User role for company " + companyId,
 				portalException);
 		}
+	}
+
+	private boolean _isGroupAdmin(PermissionChecker permissionChecker) {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return false;
+		}
+
+		return permissionChecker.isGroupAdmin(serviceContext.getScopeGroupId());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
@@ -14,9 +14,12 @@
 
 package com.liferay.users.admin.internal.search.spi.model.permission.contributor;
 
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ContactTable;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
@@ -24,10 +27,15 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.ContactLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.search.spi.model.permission.SearchPermissionFilterContributor;
+
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -55,6 +63,9 @@ public class UserSearchPermissionFilterContributor
 		if (_isGroupAdmin(permissionChecker)) {
 			_addAllUsersFilter(booleanFilter, companyId);
 		}
+		else {
+			_addCreatedUsersFilter(booleanFilter, companyId, userId);
+		}
 	}
 
 	private void _addAllUsersFilter(
@@ -77,6 +88,36 @@ public class UserSearchPermissionFilterContributor
 		}
 	}
 
+	private void _addCreatedUsersFilter(
+		BooleanFilter booleanFilter, long companyId, long userId) {
+
+		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
+			ContactTable.INSTANCE.classPK
+		).from(
+			ContactTable.INSTANCE
+		).where(
+			ContactTable.INSTANCE.companyId.eq(
+				companyId
+			).and(
+				ContactTable.INSTANCE.userId.eq(userId)
+			).and(
+				ContactTable.INSTANCE.classNameId.eq(
+					_portal.getClassNameId(User.class))
+			)
+		);
+
+		List<Long> createdUserIds = _contactLocalService.dslQuery(dslQuery);
+
+		if (!createdUserIds.isEmpty()) {
+			TermsFilter userIdTermsFilter = new TermsFilter(Field.USER_ID);
+
+			userIdTermsFilter.addValues(
+				ArrayUtil.toStringArray(createdUserIds.toArray(new Long[0])));
+
+			booleanFilter.add(userIdTermsFilter);
+		}
+	}
+
 	private boolean _isGroupAdmin(PermissionChecker permissionChecker) {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
@@ -90,6 +131,12 @@ public class UserSearchPermissionFilterContributor
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		UserSearchPermissionFilterContributor.class);
+
+	@Reference
+	private ContactLocalService _contactLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
@@ -50,10 +50,17 @@ public class UserSearchPermissionFilterContributor
 			return;
 		}
 
+		_addAllUsersFilter(booleanFilter, companyId);
+	}
+
+	private void _addAllUsersFilter(
+		BooleanFilter booleanFilter, long companyId) {
+
 		try {
 			TermsFilter roleIdsTermsFilter = new TermsFilter(Field.ROLE_IDS);
 
-			Role role = roleLocalService.getRole(companyId, RoleConstants.USER);
+			Role role = _roleLocalService.getRole(
+				companyId, RoleConstants.USER);
 
 			roleIdsTermsFilter.addValue(String.valueOf(role.getRoleId()));
 
@@ -66,10 +73,10 @@ public class UserSearchPermissionFilterContributor
 		}
 	}
 
-	@Reference
-	protected RoleLocalService roleLocalService;
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		UserSearchPermissionFilterContributor.class);
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserSearchTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserSearchTest.java
@@ -29,11 +29,13 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
@@ -119,41 +121,49 @@ public class UserSearchTest {
 			"Indexer<User> must be resolved for UserLocalServiceImpl.search",
 			indexer);
 
-		Hits hits = userLocalService.search(
-			TestPropsValues.getCompanyId(), keywords, status, userParams, start,
-			end, new Sort());
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
-		List<Long> testUserIdsList = Arrays.asList(
-			_groupAdminUser.getUserId(), _groupMemberUser.getUserId(),
-			_nongroupMemberUser.getUserId());
+		try {
+			Hits hits = userLocalService.search(
+				TestPropsValues.getCompanyId(), keywords, status, userParams,
+				start, end, new Sort());
 
-		Stream<Document> documentsStream = SearchStreamUtil.stream(
-			hits.toList());
+			List<Long> testUserIdsList = Arrays.asList(
+				_groupAdminUser.getUserId(), _groupMemberUser.getUserId(),
+				_nongroupMemberUser.getUserId());
 
-		Set<Long> hitsUserIdsSet = documentsStream.map(
-			document -> Long.valueOf(document.get(Field.USER_ID))
-		).collect(
-			Collectors.toSet()
-		);
+			Stream<Document> documentsStream = SearchStreamUtil.stream(
+				hits.toList());
 
-		assertContainsAll(testUserIdsList, hitsUserIdsSet);
-
-		List<User> users = usersAdmin.getUsers(hits);
-
-		Assert.assertNotNull(
-			"null should NOT be returned but one userId was a stale document " +
-				"with no model in persistence: " + hitsUserIdsSet,
-			users);
-
-		Stream<User> usersStream = SearchStreamUtil.stream(users);
-
-		assertContainsAll(
-			testUserIdsList,
-			usersStream.map(
-				User::getUserId
+			Set<Long> hitsUserIdsSet = documentsStream.map(
+				document -> Long.valueOf(document.get(Field.USER_ID))
 			).collect(
 				Collectors.toSet()
-			));
+			);
+
+			assertContainsAll(testUserIdsList, hitsUserIdsSet);
+
+			List<User> users = usersAdmin.getUsers(hits);
+
+			Assert.assertNotNull(
+				"null should NOT be returned but one userId was a stale " +
+					"document with no model in persistence: " + hitsUserIdsSet,
+				users);
+
+			Stream<User> usersStream = SearchStreamUtil.stream(users);
+
+			assertContainsAll(
+				testUserIdsList,
+				usersStream.map(
+					User::getUserId
+				).collect(
+					Collectors.toSet()
+				));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	@Rule


### PR DESCRIPTION
Ticket: https://issues.liferay.com/browse/LPS-130651

From @ericyanlr:

> This is a continuation of the Permission Filter changes from [LPS-130220](https://issues.liferay.com/browse/LPS-130220) (which has been partially reverted)
> 
> **Goal of Proposed Fix**
> The goal of this fix is to:
> - Resolve the slow loading of Users & Organizations page
> - While preserving the current expected behavior for Site Memberships / Accounts / Users & Orgs, such as:
>   - Users having the ability to see users that they created
>   - Site Administrators being able to see all users
>   - Account Managers being able to see all Account Entry users
> - And also avoid re-introducing regressions from our first attempt:
>   -  LPS-130626 User with add user permission not able to view the user he added 
>   -  LPS-130611 User with Account Manager role not able to view the account user 
>   -  LPS-130601 Comparison failure on UserLocalServiceTest.testSearchWithGroupId 
> 
> The approach I took is to expand the permission filtering criteria only when needed and when the requesting user has the proper permissions. And to have clearly defined conditions, which allows us to properly return the expected subset of users, instead of just returning all users.