### PR TITLE
LPS-179576 Feature flag test rule

### DIFF
--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -47,14 +47,13 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.kernel.zip.ZipWriterFactoryUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PropsUtil;
 
 import java.io.File;
 
@@ -218,13 +217,9 @@ public class FragmentsImporterTest {
 		Assert.assertFalse(fragmentEntries.isEmpty());
 	}
 
+	@FeatureFlags("LPS-158675")
 	@Test
 	public void testImportFragmentsWithFolderResources() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-158675", "true"
-			).build());
-
 		File fileWithFolderResources = _generateZipFileWithFolderResources();
 
 		ServiceContextThreadLocal.pushServiceContext(
@@ -265,11 +260,6 @@ public class FragmentsImporterTest {
 		Assert.assertEquals("image2.png", fileEntry.getTitle());
 
 		FileUtil.delete(fileWithFolderResources);
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-158675", "false"
-			).build());
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentCollectionStagingTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentCollectionStagingTest.java
@@ -34,11 +34,10 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PropsUtil;
 
 import java.util.Map;
 
@@ -69,14 +68,10 @@ public class FragmentCollectionStagingTest {
 		_liveGroup = GroupTestUtil.addGroup();
 	}
 
+	@FeatureFlags("LPS-158675")
 	@Test
 	public void testFragmentResourcesWithFoldersCopiedWhenLocalStagingActivated()
 		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-158675", "true"
-			).build());
 
 		FragmentCollection fragmentCollection =
 			FragmentTestUtil.addFragmentCollection(_liveGroup.getGroupId());
@@ -121,11 +116,6 @@ public class FragmentCollectionStagingTest {
 		Assert.assertTrue(resourcesMap.containsKey("Image1"));
 		Assert.assertTrue(resourcesMap.containsKey("Folder1/Image2"));
 		Assert.assertTrue(resourcesMap.containsKey("Folder1/Folder2/Image3"));
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-158675", "false"
-			).build());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testIntegration/java/com/liferay/headless/user/notification/resource/v1_0/test/UserNotificationResourceTest.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testIntegration/java/com/liferay/headless/user/notification/resource/v1_0/test/UserNotificationResourceTest.java
@@ -23,19 +23,18 @@ import com.liferay.portal.kernel.notifications.NotificationEvent;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.util.PropsUtil;
 
 import java.util.Date;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
 /**
  * @author Carlos Correa
  */
+@FeatureFlags("LPS-83384")
 @RunWith(Arquillian.class)
 public class UserNotificationResourceTest
 	extends BaseUserNotificationResourceTestCase {
@@ -47,22 +46,6 @@ public class UserNotificationResourceTest
 
 		_irrelevantUser = UserTestUtil.addGroupAdminUser(irrelevantGroup);
 		_testUser = UserTestUtil.addGroupAdminUser(testGroup);
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-83384", "true"
-			).build());
-	}
-
-	@After
-	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-83384", "false"
-			).build());
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.props.test.util.PropsTemporarySwapper;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -68,38 +68,33 @@ public class CheckKBArticleSchedulerJobConfigurationTest {
 		UserTestUtil.setUser(TestPropsValues.getUser());
 	}
 
+	@FeatureFlags("LPS-165476")
 	@Test
 	public void testExpireFileEntry() throws Exception {
-		try (PropsTemporarySwapper propsTemporarySwapper =
-				new PropsTemporarySwapper(
-					"feature.flag.LPS-165476", Boolean.TRUE.toString())) {
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + (Time.MINUTE * 5));
 
-			Date expirationDate = new Date(
-				System.currentTimeMillis() + (Time.MINUTE * 5));
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, UserLocalServiceUtil.getDefaultUserId(_group.getCompanyId()),
+			PortalUtil.getClassNameId(KBFolder.class.getName()), 0,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, expirationDate, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group, _user.getUserId()));
 
-			KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
-				null,
-				UserLocalServiceUtil.getDefaultUserId(_group.getCompanyId()),
-				PortalUtil.getClassNameId(KBFolder.class.getName()), 0,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				null, null, expirationDate, null, null,
-				ServiceContextTestUtil.getServiceContext(
-					_group, _user.getUserId()));
+		kbArticle.setExpirationDate(
+			new Date(System.currentTimeMillis() - (Time.MINUTE * 10)));
 
-			kbArticle.setExpirationDate(
-				new Date(System.currentTimeMillis() - (Time.MINUTE * 10)));
+		kbArticle = _kbArticleLocalService.updateKBArticle(kbArticle);
 
-			kbArticle = _kbArticleLocalService.updateKBArticle(kbArticle);
+		_kbArticleLocalService.checkKBArticles();
 
-			_kbArticleLocalService.checkKBArticles();
+		kbArticle = _kbArticleLocalService.getLatestKBArticle(
+			kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
 
-			kbArticle = _kbArticleLocalService.getLatestKBArticle(
-				kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_EXPIRED, kbArticle.getStatus());
-		}
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, kbArticle.getStatus());
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -108,12 +108,11 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -154,6 +153,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Feliphe Marinho
  */
+@FeatureFlags("LPS-164801")
 @RunWith(Arquillian.class)
 public class DefaultObjectEntryManagerImplTest {
 
@@ -184,11 +184,6 @@ public class DefaultObjectEntryManagerImplTest {
 			PermissionCheckerFactoryUtil.create(_adminUser));
 
 		PrincipalThreadLocal.setName(_adminUser.getUserId());
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-164801", "true"
-			).build());
 	}
 
 	@Before

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
@@ -29,14 +29,13 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.ComplexEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -45,9 +44,9 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.IdEntityField;
 import com.liferay.portal.odata.entity.IntegerEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -96,13 +95,9 @@ public class ObjectEntryEntityModelTest {
 		_serviceTrackerMap.close();
 	}
 
+	@FeatureFlags("LPS-154672")
 	@Test
 	public void testGetEntityFieldsMap() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
 		String value = "A" + RandomTestUtil.randomString();
 
 		List<ObjectField> customObjectFields = Arrays.asList(
@@ -166,11 +161,6 @@ public class ObjectEntryEntityModelTest {
 					relatedObjectDefinition)
 			).build(),
 			_getObjectDefinitionEntityFieldsMap(objectDefinition));
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
 	}
 
 	private ObjectRelationship _addObjectRelationship(
@@ -276,10 +266,7 @@ public class ObjectEntryEntityModelTest {
 				expectedRelatedObjectDefinitionIdObjectFieldName,
 				locale -> expectedObjectFieldName, String::valueOf));
 
-		if (GetterUtil.getBoolean(
-				com.liferay.portal.kernel.util.PropsUtil.get(
-					"feature.flag.LPS-154672"))) {
-
+		if (FeatureFlagManagerUtil.isEnabled("LPS-154672")) {
 			expectedEntityFieldsMap.put(
 				objectRelationship.getName(),
 				new ComplexEntityField(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -49,13 +49,12 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PropsUtil;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,7 +64,6 @@ import javax.ws.rs.NotSupportedException;
 import org.hamcrest.CoreMatchers;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -77,6 +75,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Luis Miguel Barcos
  */
+@FeatureFlags({"LPS-153117", "LPS-164801", "LPS-176651"})
 @RunWith(Arquillian.class)
 public class ObjectEntryResourceTest {
 
@@ -89,19 +88,6 @@ public class ObjectEntryResourceTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-153117", "true"
-			).build());
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-164801", "true"
-			).build());
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-176651", "true"
-			).build());
-
 		TaxonomyCategoryResource.Builder builder =
 			TaxonomyCategoryResource.builder();
 
@@ -116,22 +102,6 @@ public class ObjectEntryResourceTest {
 				TestPropsValues.getCompanyId()),
 			TestPropsValues.getGroupId(), RandomTestUtil.randomString(),
 			new ServiceContext());
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-153117", "false"
-			).build());
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-164801", "false"
-			).build());
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-176651", "false"
-			).build());
 	}
 
 	@Before
@@ -185,21 +155,12 @@ public class ObjectEntryResourceTest {
 			_siteScopedObjectDefinition1);
 	}
 
+	@FeatureFlags("LPS-154672")
 	@Test
 	public void testFilterObjectEntriesByRelatedObjectEntries()
 		throws Exception {
 
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
 		_testFilterObjectEntriesByRelatedObjectEntries();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
 	}
 
 	@Test

--- a/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
@@ -34,11 +34,10 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -60,6 +59,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Guilherme Camacho
  */
+@FeatureFlags("LPS-135430")
 @RunWith(Arquillian.class)
 public class SalesforceObjectEntryManagerImplTest {
 
@@ -111,11 +111,6 @@ public class SalesforceObjectEntryManagerImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-135430", "true"
-			).build());
-
 		_user = TestPropsValues.getUser();
 
 		_objectDefinition =
@@ -155,11 +150,6 @@ public class SalesforceObjectEntryManagerImplTest {
 
 	@After
 	public void tearDown() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-135430", "false"
-			).build());
-
 		if (_objectDefinition != null) {
 			_objectDefinitionLocalService.deleteObjectDefinition(
 				_objectDefinition.getObjectDefinitionId());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -72,9 +72,9 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -107,6 +107,7 @@ import org.osgi.framework.FrameworkUtil;
 /**
  * @author Brian Wing Shun Chan
  */
+@FeatureFlags("LPS-173537")
 @RunWith(Arquillian.class)
 public class ObjectActionLocalServiceTest {
 
@@ -117,11 +118,6 @@ public class ObjectActionLocalServiceTest {
 
 	@Before
 	public void setUp() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-173537", "true"
-			).build());
-
 		_objectDefinition = ObjectDefinitionTestUtil.addObjectDefinition(
 			_objectDefinitionLocalService,
 			Arrays.asList(
@@ -148,11 +144,6 @@ public class ObjectActionLocalServiceTest {
 			_objectActionExecutorRegistry.getObjectActionExecutor(
 				ObjectActionExecutorConstants.KEY_GROOVY),
 			"_objectScriptingExecutor", _originalObjectScriptingExecutor);
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-173537", "false"
-			).build());
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -44,17 +44,15 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.io.Serializable;
 
 import java.util.Arrays;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -65,6 +63,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Jürgen Kappler
  */
+@FeatureFlags("LPS-176083")
 @RunWith(Arquillian.class)
 public class ObjectEntryInfoItemFieldValuesProviderTest {
 
@@ -75,11 +74,6 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 
 	@Before
 	public void setUp() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-176083", "true"
-			).build());
-
 		_group = GroupTestUtil.addGroup();
 
 		_objectDefinition =
@@ -110,14 +104,6 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			_objectDefinitionLocalService.publishCustomObjectDefinition(
 				TestPropsValues.getUserId(),
 				_objectDefinition.getObjectDefinitionId());
-	}
-
-	@After
-	public void tearDown() {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-176083", "false"
-			).build());
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
@@ -30,15 +30,13 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Arrays;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -49,6 +47,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Jürgen Kappler
  */
+@FeatureFlags("LPS-176083")
 @RunWith(Arquillian.class)
 public class ObjectEntryInfoItemFormProviderTest {
 
@@ -59,11 +58,6 @@ public class ObjectEntryInfoItemFormProviderTest {
 
 	@Before
 	public void setUp() throws Exception {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-176083", "true"
-			).build());
-
 		_objectDefinition =
 			_objectDefinitionLocalService.addCustomObjectDefinition(
 				TestPropsValues.getUserId(), false,
@@ -92,14 +86,6 @@ public class ObjectEntryInfoItemFormProviderTest {
 			_objectDefinitionLocalService.publishCustomObjectDefinition(
 				TestPropsValues.getUserId(),
 				_objectDefinition.getObjectDefinitionId());
-	}
-
-	@After
-	public void tearDown() {
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-176083", "false"
-			).build());
 	}
 
 	@Test

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 14.4.1
+Bundle-Version: 14.5.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.test.rule;
+
+import com.liferay.portal.kernel.test.rule.AbstractTestRule;
+import com.liferay.portal.kernel.test.util.PropsTestUtil;
+
+import org.junit.runner.Description;
+
+/**
+ * @author Alejandro Tardín
+ */
+public class FeatureFlagTestRule extends AbstractTestRule<Void, Void> {
+
+	public static final FeatureFlagTestRule INSTANCE =
+		new FeatureFlagTestRule();
+
+	@Override
+	protected void afterClass(Description description, Void v)
+		throws Throwable {
+
+		_setFeatureFlags(description, false);
+	}
+
+	@Override
+	protected void afterMethod(Description description, Void v, Object target)
+		throws Throwable {
+
+		_setFeatureFlags(description, false);
+	}
+
+	@Override
+	protected Void beforeClass(Description description) throws Throwable {
+		_setFeatureFlags(description, true);
+
+		return null;
+	}
+
+	@Override
+	protected Void beforeMethod(Description description, Object target)
+		throws Throwable {
+
+		_setFeatureFlags(description, true);
+
+		return null;
+	}
+
+	private void _setFeatureFlags(Description description, boolean enabled) {
+		FeatureFlags featureFlags = description.getAnnotation(
+			FeatureFlags.class);
+
+		if (featureFlags != null) {
+			for (String key : featureFlags.value()) {
+				PropsTestUtil.setProps(
+					"feature.flag." + key, Boolean.toString(enabled));
+			}
+		}
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/test/rule/FeatureFlags.java
+++ b/portal-test/src/com/liferay/portal/test/rule/FeatureFlags.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.test.rule;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface FeatureFlags {
+
+	public String[] value();
+
+}

--- a/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
@@ -54,6 +54,7 @@ public class LiferayIntegrationTestRule extends AggregateTestRule {
 		testRules.add(DeleteAfterTestRunMethodTestRule.INSTANCE);
 		testRules.add(InjectTestRule.INSTANCE);
 		testRules.add(PortalRunModeClassTestRule.INSTANCE);
+		testRules.add(FeatureFlagTestRule.INSTANCE);
 
 		return testRules.toArray(new TestRule[0]);
 	}

--- a/portal-test/src/com/liferay/portal/test/rule/packageinfo
+++ b/portal-test/src/com/liferay/portal/test/rule/packageinfo
@@ -1,1 +1,1 @@
-version 3.4.0
+version 3.5.0


### PR DESCRIPTION
Adds `FeatureFlags` test annotation to simplify feature flags management. Works at class and method level. 