### PR TITLE
LPS-177107 Searching for user screenname with quotes does not yield results

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1598,7 +1598,7 @@
 			},
 			"screenName": {
 				"store": true,
-				"type": "keyword"
+				"type": "text"
 			},
 			"size": {
 				"store": true,

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -1609,7 +1609,7 @@
 				},
 				"screenName": {
 					"store": true,
-					"type": "keyword"
+					"type": "text"
 				},
 				"size": {
 					"store": true,

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/QueryPreProcessConfiguration.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/QueryPreProcessConfiguration.java
@@ -40,7 +40,7 @@ public interface QueryPreProcessConfiguration {
 	public String[] fieldNamePatterns();
 
 	@Meta.AD(
-		deflt = "assetTagNames|entryClassPK|extension|fileEntryTypeId|screenName",
+		deflt = "assetTagNames|entryClassPK|extension|fileEntryTypeId",
 		name = "keyword-field-names", required = false
 	)
 	public String[] keywordFieldNames();

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/SearchRequestBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/SearchRequestBuilderTest.java
@@ -237,11 +237,7 @@ public class SearchRequestBuilderTest {
 		_addUser("firstName3", "lastName1", "name2");
 		_addUser("firstName1", "lastName2", "name3");
 
-		FieldSort fieldSort = _sorts.field("screenName", SortOrder.DESC);
-
-		_assertSearch("[name3, name2, name1]", "screenName", "name", fieldSort);
-
-		fieldSort = _sorts.field("userName", SortOrder.ASC);
+		FieldSort fieldSort = _sorts.field("userName", SortOrder.ASC);
 
 		_assertSearch(
 			"[firstname1 lastname2, firstname2 lastname3, firstname3 " +

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/SearchRequestBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/SearchRequestBuilderTest.java
@@ -237,7 +237,12 @@ public class SearchRequestBuilderTest {
 		_addUser("firstName3", "lastName1", "name2");
 		_addUser("firstName1", "lastName2", "name3");
 
-		FieldSort fieldSort = _sorts.field("userName", SortOrder.ASC);
+		FieldSort fieldSort = _sorts.field(
+			"screenName_sortable", SortOrder.DESC);
+
+		_assertSearch("[name3, name2, name1]", "screenName", "name", fieldSort);
+
+		fieldSort = _sorts.field("userName", SortOrder.ASC);
 
 		_assertSearch(
 			"[firstname1 lastname2, firstname2 lastname3, firstname3 " +

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/src/testIntegration/resources/com/liferay/portal/search/tuning/synonyms/web/test/dependencies/SynonymSearchTest-overrideTypeMappings.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/src/testIntegration/resources/com/liferay/portal/search/tuning/synonyms/web/test/dependencies/SynonymSearchTest-overrideTypeMappings.json
@@ -812,7 +812,7 @@
 			},
 			"screenName": {
 				"store": true,
-				"type": "keyword"
+				"type": "text"
 			},
 			"size": {
 				"store": true,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-177107

Author: @joshuacords

Followup to https://github.com/liferay-usm/liferay-portal/pull/1001

**Notes:** You still retain the ability to sort by screenName, this is possible because a screenName_sortable is added by the search infrastructure. Searching by exact match is now possible, ie "usersn" will find the user with "usersn".