### PR TITLE
workspace.cx.cleanup

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionGlobExpansion/build.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionGlobExpansion/build.gradle
@@ -10,7 +10,6 @@ runGradleTest {
 
 		File clientExtensionConfigJSONFile = new File(clientExtensionBuildDir, "client-extension.client-extension-config.json")
 
-		assert clientExtensionConfigJSONFile.text.contains('"doNotExpand=*.lfr.dev"')
 		assert clientExtensionConfigJSONFile.text.contains('"fooUrls=foo.json\\nfoo.txt"')
 		assert clientExtensionConfigJSONFile.text.contains('"jsonUrls=foo.json\\none/two/three/bar.json"')
 		assert clientExtensionConfigJSONFile.text.contains('"singleURL=bar.txt\\nfoo.txt"')

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionGlobExpansion/client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionGlobExpansion/client-extension/client-extension.yaml
@@ -1,12 +1,5 @@
 assemble:
     - into: static
-bar-client-extension:
-    doNotExpand:
-        - "*.lfr.dev"
-    name: Bar Client Extension
-    pid: com.liferay.bar.configuration.BarConfiguration
-    securityMode: domain
-    type: instanceSettings
 foo-client-extension:
     fooUrls:
         - "foo.*"

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -770,7 +770,7 @@ public class ClientExtensionProjectConfigurator
 
 	private void _validateClientExtension(ClientExtension clientExtension) {
 		if (Objects.equals(clientExtension.type, "batch")) {
-			if (!clientExtension.typeSettings.containsKey(
+			if (!clientExtension.unmappedProperties.containsKey(
 					"oAuthApplicationHeadlessServer")) {
 
 				throw new GradleException(
@@ -781,7 +781,7 @@ public class ClientExtensionProjectConfigurator
 			}
 		}
 		else if (Objects.equals(clientExtension.type, "instanceSettings")) {
-			if (!clientExtension.typeSettings.containsKey("pid")) {
+			if (!clientExtension.unmappedProperties.containsKey("pid")) {
 				throw new GradleException(
 					StringBundler.concat(
 						"Client extension ", clientExtension.id, " with type ",

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -41,7 +41,6 @@ import com.liferay.petra.string.StringBundler;
 import groovy.lang.Closure;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 
 import java.nio.file.FileVisitResult;
@@ -713,7 +712,7 @@ public class ClientExtensionProjectConfigurator
 			return _yamlObjectMapper.createObjectNode();
 		}
 
-		try (FileReader fileReader = new FileReader(file)) {
+		try {
 			return _yamlObjectMapper.readTree(file);
 		}
 		catch (IOException ioException) {

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,6 +52,15 @@ public class ClientExtension {
 			"baseURL",
 			unmappedProperties.getOrDefault(
 				"baseURL", "${portalURL}/o/" + projectName));
+
+		if (Objects.equals("configuration", classification)) {
+			configMap.put(
+				"baseURL",
+				unmappedProperties.getOrDefault(
+					"baseURL",
+					"$[conf:.serviceScheme]://$[conf:.serviceAddress]"));
+		}
+
 		configMap.put("description", description);
 		configMap.put(
 			"dxp.lxc.liferay.com.virtualInstanceId", virtualInstanceId);
@@ -72,16 +82,6 @@ public class ClientExtension {
 					configMap.put(entry.getKey(), entry.getValue());
 				}
 			});
-
-		if (type.equals("oAuthApplicationHeadlessServer") ||
-			type.equals("oAuthApplicationUserAgent")) {
-
-			configMap.put(
-				"homePageURL",
-				unmappedProperties.getOrDefault(
-					"homePageURL",
-					"$[conf:.serviceScheme]://$[conf:.serviceAddress]"));
-		}
 
 		configMap.put("typeSettings", _encode(unmappedProperties));
 

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
@@ -66,7 +66,6 @@ public class ClientExtension {
 			"dxp.lxc.liferay.com.virtualInstanceId", virtualInstanceId);
 		configMap.put("name", name);
 		configMap.put("projectName", projectName);
-		configMap.put("properties", _encode(properties));
 		configMap.put("sourceCodeURL", sourceCodeURL);
 		configMap.put("type", type);
 		configMap.put(
@@ -83,7 +82,10 @@ public class ClientExtension {
 				}
 			});
 
-		configMap.put("typeSettings", _encode(unmappedProperties));
+		if (Objects.equals("frontend", classification)) {
+			configMap.put("properties", _encode(properties));
+			configMap.put("typeSettings", _encode(unmappedProperties));
+		}
 
 		jsonMap.put(pid + "~" + id, configMap);
 

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
@@ -38,11 +38,6 @@ import java.util.stream.Stream;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ClientExtension {
 
-	@JsonAnySetter
-	public void unmappedProperty(String name, Object value) {
-		unmappedProperties.put(name, value);
-	}
-
 	public Map<String, Object> toJSONMap(String pid) {
 		Map<String, Object> jsonMap = new HashMap<>();
 
@@ -53,7 +48,7 @@ public class ClientExtension {
 			unmappedProperties.getOrDefault(
 				"baseURL", "${portalURL}/o/" + projectName));
 
-		if (Objects.equals("configuration", classification)) {
+		if (Objects.equals(classification, "configuration")) {
 			configMap.put(
 				"baseURL",
 				unmappedProperties.getOrDefault(
@@ -73,11 +68,11 @@ public class ClientExtension {
 			unmappedProperties.getOrDefault(
 				"webContextPath", "/" + projectName));
 
-		if (!Objects.equals("frontend", classification)) {
+		if (!Objects.equals(classification, "frontend")) {
 			configMap.putAll(unmappedProperties);
 		}
 
-		if (Objects.equals("frontend", classification)) {
+		if (Objects.equals(classification, "frontend")) {
 			configMap.put("properties", _encode(properties));
 			configMap.put("typeSettings", _encode(unmappedProperties));
 		}
@@ -85,6 +80,11 @@ public class ClientExtension {
 		jsonMap.put(pid + "~" + id, configMap);
 
 		return jsonMap;
+	}
+
+	@JsonAnySetter
+	public void unmappedProperty(String name, Object value) {
+		unmappedProperties.put(name, value);
 	}
 
 	public String classification = "static";

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
@@ -38,8 +38,8 @@ import java.util.stream.Stream;
 public class ClientExtension {
 
 	@JsonAnySetter
-	public void ignored(String name, Object value) {
-		typeSettings.put(name, value);
+	public void unmappedProperty(String name, Object value) {
+		unmappedProperties.put(name, value);
 	}
 
 	public Map<String, Object> toJSONMap(String pid) {
@@ -49,7 +49,7 @@ public class ClientExtension {
 
 		configMap.put(
 			"baseURL",
-			typeSettings.getOrDefault(
+			unmappedProperties.getOrDefault(
 				"baseURL", "${portalURL}/o/" + projectName));
 		configMap.put("description", description);
 		configMap.put(
@@ -61,9 +61,10 @@ public class ClientExtension {
 		configMap.put("type", type);
 		configMap.put(
 			"webContextPath",
-			typeSettings.getOrDefault("webContextPath", "/" + projectName));
+			unmappedProperties.getOrDefault(
+				"webContextPath", "/" + projectName));
 
-		Set<Map.Entry<String, Object>> set = typeSettings.entrySet();
+		Set<Map.Entry<String, Object>> set = unmappedProperties.entrySet();
 
 		set.forEach(
 			entry -> {
@@ -77,12 +78,12 @@ public class ClientExtension {
 
 			configMap.put(
 				"homePageURL",
-				typeSettings.getOrDefault(
+				unmappedProperties.getOrDefault(
 					"homePageURL",
 					"$[conf:.serviceScheme]://$[conf:.serviceAddress]"));
 		}
 
-		configMap.put("typeSettings", _encode(typeSettings));
+		configMap.put("typeSettings", _encode(unmappedProperties));
 
 		jsonMap.put(pid + "~" + id, configMap);
 
@@ -99,7 +100,7 @@ public class ClientExtension {
 	public String type;
 
 	@JsonIgnore
-	public Map<String, Object> typeSettings = new HashMap<>();
+	public Map<String, Object> unmappedProperties = new HashMap<>();
 
 	@JsonProperty("dxp.lxc.liferay.com.virtualInstanceId")
 	public String virtualInstanceId = "default";

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
@@ -68,9 +68,7 @@ public class ClientExtension {
 			unmappedProperties.getOrDefault(
 				"webContextPath", "/" + projectName));
 
-		if (!Objects.equals(classification, "frontend")) {
-			configMap.putAll(unmappedProperties);
-		}
+		configMap.putAll(unmappedProperties);
 
 		if (Objects.equals(classification, "frontend")) {
 			configMap.put("properties", _encode(properties));

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/client/extension/ClientExtension.java
@@ -73,14 +73,9 @@ public class ClientExtension {
 			unmappedProperties.getOrDefault(
 				"webContextPath", "/" + projectName));
 
-		Set<Map.Entry<String, Object>> set = unmappedProperties.entrySet();
-
-		set.forEach(
-			entry -> {
-				if (!pid.contains("CETConfiguration")) {
-					configMap.put(entry.getKey(), entry.getValue());
-				}
-			});
+		if (!Objects.equals("frontend", classification)) {
+			configMap.putAll(unmappedProperties);
+		}
 
 		if (Objects.equals("frontend", classification)) {
 			configMap.put("properties", _encode(properties));

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/task/CreateClientExtensionConfigTask.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/task/CreateClientExtensionConfigTask.java
@@ -129,7 +129,7 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 			}
 
 			if (Objects.equals(clientExtension.classification, "frontend")) {
-				_expandWildcards(clientExtension.typeSettings);
+				_expandWildcards(clientExtension.unmappedProperties);
 
 				pluginPackageProperties.put(
 					"Liferay-Client-Extension-Frontend", "static/");
@@ -139,7 +139,9 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 				clientExtension.type + ".pid");
 
 			if (Objects.equals(clientExtension.type, "instanceSettings")) {
-				pid = clientExtension.typeSettings.remove("pid") + ".scoped";
+				pid =
+					clientExtension.unmappedProperties.remove("pid") +
+						".scoped";
 			}
 
 			if (pid != null) {
@@ -154,7 +156,7 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 		Map<String, String> substitutionMap = stream.flatMap(
 			clientExtension -> {
 				Set<Map.Entry<String, Object>> entrySet =
-					clientExtension.typeSettings.entrySet();
+					clientExtension.unmappedProperties.entrySet();
 
 				Stream<Map.Entry<String, Object>> entrySetStream =
 					entrySet.stream();
@@ -273,7 +275,7 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 		}
 	}
 
-	private void _expandWildcards(Map<String, Object> typeSettings) {
+	private void _expandWildcards(Map<String, Object> unmappedProperties) {
 		File clientExtensionBuildDir = new File(
 			_project.getBuildDir(),
 			ClientExtensionProjectConfigurator.CLIENT_EXTENSION_BUILD_DIR);
@@ -286,7 +288,7 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 
 		Path staticDirPath = staticDir.toPath();
 
-		for (Map.Entry<String, Object> entry : typeSettings.entrySet()) {
+		for (Map.Entry<String, Object> entry : unmappedProperties.entrySet()) {
 			Object currentValue = entry.getValue();
 
 			if ((currentValue instanceof String) &&

--- a/modules/sdk/gradle-plugins-workspace/src/main/resources/com/liferay/gradle/plugins/workspace/task/dependencies/templates/frontend/LCP.json.tpl
+++ b/modules/sdk/gradle-plugins-workspace/src/main/resources/com/liferay/gradle/plugins/workspace/task/dependencies/templates/frontend/LCP.json.tpl
@@ -13,10 +13,22 @@
 	},
 	"id": "__CLIENT_EXTENSION_ID__",
 	"kind": "Deployment",
+	"livenessProbe": {
+		"httpGet": {
+			"path": "/",
+			"port": 80
+		}
+	},
 	"loadBalancer": {
 		"cdn": true,
 		"targetPort": 80
 	},
 	"memory": 50,
+	"readinessProbe": {
+		"httpGet": {
+			"path": "/",
+			"port": 80
+		}
+	},
 	"scale": 1
 }


### PR DESCRIPTION
- LPS-179580 Add default readinessProbe/livenessProbe to the generated LCP.json by the workspace plugin
- LPS-000000 rename to unmapped properties
- LPS-000000 move from legacy homePageURL to standarized baseURL
- LPS-000000 only add properties and typeSettings to frontend client extensions
- LPS-000000 add unmapped properties to all but frontend client extensions
- LPS-000000 SF
- LPS-182369 remove unused
