### PR TITLE
LPS-146891 UserTestUtil.addOmniAdminUser creates user in wrong company

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/util/UserTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/UserTestUtil.java
@@ -95,7 +95,7 @@ public class UserTestUtil {
 	}
 
 	public static User addOmniAdminUser() throws Exception {
-		Company company = CompanyLocalServiceUtil.getCompanyByMx(
+		Company company = CompanyLocalServiceUtil.getCompanyByWebId(
 			PropsUtil.get(PropsKeys.COMPANY_DEFAULT_WEB_ID));
 
 		return addCompanyAdminUser(company);


### PR DESCRIPTION
This is an update for [LPS-146891](https://issues.liferay.com/browse/LPS-146891).<br/><br/>/cc @stian-sigvartsen