### PR TITLE
POSHI-556 Bump the version for the VSCode Poshi extension to prepare for publish

### DIFF
--- a/modules/test/poshi/poshi-vscode/README.markdown
+++ b/modules/test/poshi/poshi-vscode/README.markdown
@@ -96,6 +96,11 @@ This is a work in progress. If enabled, it is recommended that you disable forma
 
 ## Release Notes
 
+### 0.3.0
+
+- POSHI-406: Adds command to run test case from cursor position
+- POSHI-485: Update syntax highlighting
+
 ### 0.2.0
 
 - Provides method completion from multiple possible files

--- a/modules/test/poshi/poshi-vscode/package.json
+++ b/modules/test/poshi/poshi-vscode/package.json
@@ -116,7 +116,7 @@
 	"publisher": "LiferayInc",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/drewbrokke/vscode-poshi-language-support"
+		"url": "https://github.com/liferay/liferay-portal/tree/master/modules/test/poshi/poshi-vscode"
 	},
 	"scripts": {
 		"compile": "tsc -p ./",

--- a/modules/test/poshi/poshi-vscode/package.json
+++ b/modules/test/poshi/poshi-vscode/package.json
@@ -126,5 +126,5 @@
 		"vscode:prepublish": "npm run compile",
 		"watch": "tsc -watch -p ./"
 	},
-	"version": "0.2.0"
+	"version": "0.3.0"
 }


### PR DESCRIPTION
This is an update for [POSHI-556](https://issues.liferay.com/browse/POSHI-556).