### PR TITLE
LPS-190915 20230726

### DIFF
--- a/modules/util/source-formatter-standalone/build.gradle
+++ b/modules/util/source-formatter-standalone/build.gradle
@@ -5,11 +5,18 @@ dependencies {
 	compileInclude group: "commons-io", name: "commons-io", version: "2.11.0"
 	compileInclude group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileInclude group: "commons-logging", name: "commons-logging", version: "1.2"
+	compileInclude group: "commons-beanutils", name: "commons-beanutils", version: "1.9.4"
+	compileInclude group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
+	compileInclude group: "com.google.collections", name: "google-collections", version: "1.0"
+	compileInclude group: "org.slf4j", name: "slf4j-api", version: "1.7.26"
+	compileInclude group: "org.javassist", name: "javassist", version: "3.28.0-GA"
+	compileInclude group: "org.apache.commons", name: "commons-lang3", version: "3.0"
 	compileInclude(group: "jaxen", name: "jaxen", version: "1.1.1") {
 		exclude group: "com.ibm.icu", module: "icu4j"
 	}
 	compileInclude group: "junit", name: "junit", version: "4.13.1"
 	compileInclude group: "org.antlr", name: "antlr4-runtime", version: "4.8-1"
+	compileInclude group: 'antlr', name: 'antlr', version: '2.7.7'
 	compileInclude group: "org.apache.ant", name: "ant", version: "1.10.11"
 	compileInclude group: "org.apache.maven", name: "maven-artifact", version: "3.3.9"
 	compileInclude group: "org.dom4j", name: "dom4j", version: "2.1.3"
@@ -17,6 +24,7 @@ dependencies {
 	compileInclude group: "org.reflections", name: "reflections", "version": "0.10.2"
 	compileInclude group: "xerces", name: "xercesImpl", version: "2.12.2"
 
+	compileInclude group: "com.liferay", name: "com.liferay.petra.concurrent", version: "5.1.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.function", version: "5.5.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.lang", version: "1.0.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.nio", version: "1.0.0"

--- a/modules/util/source-formatter/build.gradle
+++ b/modules/util/source-formatter/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	compileInclude group: "org.codehaus.groovy", name: "groovy", version: "2.4.21"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
-	compileOnly group: "com.liferay", name: "com.liferay.petra.concurrent", version: "1.1.0"
+	compileOnly group: "com.liferay", name: "com.liferay.petra.concurrent", version: "5.1.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.memory", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.reflect", version: "1.1.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.xml", version: "1.0.0"

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1016,15 +1016,17 @@ public class SourceFormatter {
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.GLOB, "**/node_modules_cache/**"),
 				new ExcludeSyntaxPattern(
+					ExcludeSyntax.GLOB,
+					"**/test*/**/dependencies/**/*.[jlw]ar/**"),
+				new ExcludeSyntaxPattern(
+					ExcludeSyntax.GLOB, "**/test*/**/dependencies/**/*.zip/**"),
+				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					".*/frontend-theme-unstyled/.*/_unstyled/css/clay/.+"),
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					".*/frontend-theme-unstyled/.*/_unstyled/images/(aui|" +
 						"clay|lexicon)/.+"),
-				new ExcludeSyntaxPattern(
-					ExcludeSyntax.REGEX,
-					".*/tests?/.*/dependencies/.+\\.(jar|lar|war|zip)/.+"),
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					"^((?!/frontend-js-node-shims/src/).)*/node_modules/.*"),

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -746,19 +746,11 @@ public class SourceFormatterUtil {
 			git(
 				Arrays.asList("ls-files", "--full-name"), baseDirName,
 				pathMatchers, includeSubrepositories,
-				line -> {
-					try {
-						File file = new File(
-							_gitToplevel,
-							StringUtil.replace(
-								line, CharPool.BACK_SLASH, CharPool.SLASH));
-
-						gitFiles.add(file.getCanonicalPath());
-					}
-					catch (IOException ioException) {
-						throw new RuntimeException(ioException);
-					}
-				});
+				line -> gitFiles.add(
+					StringBundler.concat(
+						_gitToplevel, StringPool.FORWARD_SLASH,
+						StringUtil.replace(
+							line, CharPool.BACK_SLASH, CharPool.SLASH))));
 
 			return gitFiles;
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -946,7 +945,7 @@ public class SourceFormatterUtil {
 					_fileSystem.getPathMatcher(
 						excludeSyntax.getValue() + ":" + excludePattern));
 
-				if (Objects.equals(ExcludeSyntax.GLOB, excludeSyntax)) {
+				if (excludeSyntax.equals(ExcludeSyntax.GLOB)) {
 					_excludeFileGlobs.add(excludePattern);
 				}
 			}
@@ -1004,9 +1003,7 @@ public class SourceFormatterUtil {
 						_fileSystem.getPathMatcher(
 							excludeSyntax.getValue() + ":" + excludePattern));
 
-					if (Objects.equals(
-							ExcludeSyntax.GLOB, excludeSyntax.getValue())) {
-
+					if (excludeSyntax.equals(ExcludeSyntax.GLOB)) {
 						excludeFilePathMatcherGlobsList.add(excludePattern);
 					}
 				}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -425,10 +425,10 @@ public class SourceFormatterUtil {
 		}
 
 		try {
-			Process git = processBuilder.start();
+			Process process = processBuilder.start();
 
 			BufferedReader bufferedReader = new BufferedReader(
-				new InputStreamReader(git.getInputStream()));
+				new InputStreamReader(process.getInputStream()));
 
 			String line = null;
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -431,9 +431,9 @@ public class SourceFormatterUtil {
 			BufferedReader bufferedReader = new BufferedReader(
 				new InputStreamReader(git.getInputStream()));
 
-			for (String line = bufferedReader.readLine(); line != null;
-				 line = bufferedReader.readLine()) {
+			String line = null;
 
+			while ((line = bufferedReader.readLine()) != null) {
 				consumer.accept(line);
 			}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -367,26 +367,24 @@ public class SourceFormatterUtil {
 				pathMatchers.getExcludeFileGlobs(),
 				excludeGlob -> filters.add(excludePrefix + excludeGlob));
 
-			Map<String, List<String>> excludeDirPathMatchersGlobsMap =
+			Map<String, List<String>> excludeDirGlobsMap =
 				pathMatchers.getExcludeDirGlobsMap();
 
-			for (List<String> excludeDirPathGlobs :
-					excludeDirPathMatchersGlobsMap.values()) {
-
+			for (List<String> excludeDirGlobs : excludeDirGlobsMap.values()) {
 				ListUtil.isNotEmptyForEach(
-					excludeDirPathGlobs,
-					excludeGlob -> filters.add(excludePrefix + excludeGlob));
+					excludeDirGlobs,
+					excludeDirGlob -> filters.add(
+						excludePrefix + excludeDirGlob));
 			}
 
-			Map<String, List<String>> excludeFilePathMatchersGlobsMap =
+			Map<String, List<String>> excludeFileGlobsMap =
 				pathMatchers.getExcludeFileGlobsMap();
 
-			for (List<String> excludeFileGlobs :
-					excludeFilePathMatchersGlobsMap.values()) {
-
+			for (List<String> excludeFileGlobs : excludeFileGlobsMap.values()) {
 				ListUtil.isNotEmptyForEach(
 					excludeFileGlobs,
-					excludeGlob -> filters.add(excludePrefix + excludeGlob));
+					excludeFileGlob -> filters.add(
+						excludePrefix + excludeFileGlob));
 			}
 
 			ListUtil.isNotEmptyForEach(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -718,6 +719,8 @@ public class SourceFormatterUtil {
 			if (excludeSyntax.equals(ExcludeSyntax.GLOB) &&
 				excludePattern.endsWith("/**")) {
 
+				_excludeDirGlobs.add(excludePattern);
+
 				excludePattern = excludePattern.substring(
 					0, excludePattern.length() - 3);
 
@@ -741,6 +744,10 @@ public class SourceFormatterUtil {
 				_excludeFilePathMatchers.add(
 					_fileSystem.getPathMatcher(
 						excludeSyntax.getValue() + ":" + excludePattern));
+
+				if (Objects.equals(ExcludeSyntax.GLOB, excludeSyntax)) {
+					_excludeFileGlobs.add(excludePattern);
+				}
 			}
 		}
 
@@ -749,7 +756,9 @@ public class SourceFormatterUtil {
 			List<ExcludeSyntaxPattern> excludeSyntaxPatterns) {
 
 			List<PathMatcher> excludeDirPathMatcherList = new ArrayList<>();
+			List<String> excludeDirPathMatcherGlobsList = new ArrayList<>();
 			List<PathMatcher> excludeFilePathMatcherList = new ArrayList<>();
+			List<String> excludeFilePathMatcherGlobsList = new ArrayList<>();
 
 			for (ExcludeSyntaxPattern excludeSyntaxPattern :
 					excludeSyntaxPatterns) {
@@ -767,6 +776,8 @@ public class SourceFormatterUtil {
 
 				if (excludeSyntax.equals(ExcludeSyntax.GLOB) &&
 					excludePattern.endsWith("/**")) {
+
+					excludeDirPathMatcherGlobsList.add(excludePattern);
 
 					excludePattern = excludePattern.substring(
 						0, excludePattern.length() - 3);
@@ -791,18 +802,37 @@ public class SourceFormatterUtil {
 					excludeFilePathMatcherList.add(
 						_fileSystem.getPathMatcher(
 							excludeSyntax.getValue() + ":" + excludePattern));
+
+					if (Objects.equals(
+							ExcludeSyntax.GLOB, excludeSyntax.getValue())) {
+
+						excludeFilePathMatcherGlobsList.add(excludePattern);
+					}
 				}
 			}
 
 			_excludeDirPathMatchersMap.put(
 				propertiesFileLocation, excludeDirPathMatcherList);
+			_excludeDirGlobsMap.put(
+				propertiesFileLocation, excludeDirPathMatcherGlobsList);
 			_excludeFilePathMatchersMap.put(
 				propertiesFileLocation, excludeFilePathMatcherList);
+			_excludeFileGlobsMap.put(
+				propertiesFileLocation, excludeFilePathMatcherGlobsList);
 		}
 
 		public void addInclude(String include) {
 			_includeFilePathMatchers.add(
 				_fileSystem.getPathMatcher("glob:" + include));
+			_includeFileGlobs.add(include);
+		}
+
+		public List<String> getExcludeDirGlobs() {
+			return _excludeDirGlobs;
+		}
+
+		public Map<String, List<String>> getExcludeDirGlobsMap() {
+			return _excludeDirGlobsMap;
 		}
 
 		public List<PathMatcher> getExcludeDirPathMatchers() {
@@ -813,6 +843,14 @@ public class SourceFormatterUtil {
 			return _excludeDirPathMatchersMap;
 		}
 
+		public List<String> getExcludeFileGlobs() {
+			return _excludeFileGlobs;
+		}
+
+		public Map<String, List<String>> getExcludeFileGlobsMap() {
+			return _excludeFileGlobsMap;
+		}
+
 		public List<PathMatcher> getExcludeFilePathMatchers() {
 			return _excludeFilePathMatchers;
 		}
@@ -821,18 +859,31 @@ public class SourceFormatterUtil {
 			return _excludeFilePathMatchersMap;
 		}
 
+		public List<String> getIncludeFileGlobs() {
+			return _includeFileGlobs;
+		}
+
 		public List<PathMatcher> getIncludeFilePathMatchers() {
 			return _includeFilePathMatchers;
 		}
 
-		private List<PathMatcher> _excludeDirPathMatchers = new ArrayList<>();
-		private Map<String, List<PathMatcher>> _excludeDirPathMatchersMap =
+		private final List<String> _excludeDirGlobs = new ArrayList<>();
+		private final Map<String, List<String>> _excludeDirGlobsMap =
 			new HashMap<>();
-		private List<PathMatcher> _excludeFilePathMatchers = new ArrayList<>();
-		private Map<String, List<PathMatcher>> _excludeFilePathMatchersMap =
+		private final List<PathMatcher> _excludeDirPathMatchers =
+			new ArrayList<>();
+		private final Map<String, List<PathMatcher>>
+			_excludeDirPathMatchersMap = new HashMap<>();
+		private final List<String> _excludeFileGlobs = new ArrayList<>();
+		private final Map<String, List<String>> _excludeFileGlobsMap =
 			new HashMap<>();
-		private final FileSystem _fileSystem;
-		private List<PathMatcher> _includeFilePathMatchers = new ArrayList<>();
+		private final List<PathMatcher> _excludeFilePathMatchers =
+			new ArrayList<>();
+		private final Map<String, List<PathMatcher>>
+			_excludeFilePathMatchersMap = new HashMap<>();
+		private final List<String> _includeFileGlobs = new ArrayList<>();
+		private final List<PathMatcher> _includeFilePathMatchers =
+			new ArrayList<>();
 
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -41,7 +41,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -420,8 +419,8 @@ public class SourceFormatterUtil {
 		if (Validator.isNotNull(dir)) {
 			processBuilder.directory(new File(dir));
 		}
-		else if (_portalDir != null) {
-			processBuilder.directory(_portalDir);
+		else if (_gitToplevel != null) {
+			processBuilder.directory(_gitToplevel);
 		}
 
 		try {
@@ -693,9 +692,9 @@ public class SourceFormatterUtil {
 		List<String> lines = git(
 			Arrays.asList("rev-parse", "--show-toplevel"), null, null, false);
 
-		_portalDir = new File(lines.get(0));
+		_gitToplevel = new File(lines.get(0));
 
-		String absolutePath = _portalDir.getAbsolutePath();
+		String absolutePath = _gitToplevel.getAbsolutePath();
 
 		git(
 			Arrays.asList(
@@ -745,12 +744,12 @@ public class SourceFormatterUtil {
 			List<String> gitFiles = new ArrayList<>();
 
 			git(
-				Collections.singletonList("ls-files"), baseDirName,
+				Arrays.asList("ls-files", "--full-name"), baseDirName,
 				pathMatchers, includeSubrepositories,
 				line -> {
 					try {
 						File file = new File(
-							baseDirName,
+							_gitToplevel,
 							StringUtil.replace(
 								line, CharPool.BACK_SLASH, CharPool.SLASH));
 
@@ -905,7 +904,7 @@ public class SourceFormatterUtil {
 
 	private static final FileSystem _fileSystem = FileSystems.getDefault();
 	private static Boolean _git;
-	private static File _portalDir;
+	private static File _gitToplevel;
 	private static List<String> _sfIgnoreDirectories;
 	private static List<String> _subrepoIgnoreDirectories;
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -48,8 +48,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 /**
  * @author Igor Spasic
  * @author Brian Wing Shun Chan
@@ -333,8 +331,8 @@ public class SourceFormatterUtil {
 	}
 
 	public static List<String> git(
-		List<String> args, @Nullable String baseDirName,
-		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories) {
+		List<String> args, String baseDirName, PathMatchers pathMatchers,
+		boolean includeSubrepositories) {
 
 		List<String> result = new ArrayList<>();
 
@@ -346,9 +344,8 @@ public class SourceFormatterUtil {
 	}
 
 	public static void git(
-		List<String> args, @Nullable String baseDirName,
-		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories,
-		Consumer<String> consumer) {
+		List<String> args, String baseDirName, PathMatchers pathMatchers,
+		boolean includeSubrepositories, Consumer<String> consumer) {
 
 		List<String> allArgs = new ArrayList<>();
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -334,18 +334,20 @@ public class SourceFormatterUtil {
 	}
 
 	public static List<String> git(
-		List<String> args, @Nullable String dir,
+		List<String> args, @Nullable String baseDirName,
 		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories) {
 
 		List<String> result = new ArrayList<>();
 
-		git(args, dir, pathMatchers, includeSubrepositories, result::add);
+		git(
+			args, baseDirName, pathMatchers, includeSubrepositories,
+			result::add);
 
 		return result;
 	}
 
 	public static void git(
-		List<String> args, @Nullable String dir,
+		List<String> args, @Nullable String baseDirName,
 		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories,
 		Consumer<String> consumer) {
 
@@ -416,8 +418,8 @@ public class SourceFormatterUtil {
 
 		ProcessBuilder processBuilder = new ProcessBuilder(allArgs);
 
-		if (Validator.isNotNull(dir)) {
-			processBuilder.directory(new File(dir));
+		if (Validator.isNotNull(baseDirName)) {
+			processBuilder.directory(new File(baseDirName));
 		}
 		else if (_gitToplevel != null) {
 			processBuilder.directory(_gitToplevel);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -415,8 +415,8 @@ public class SourceFormatterUtil {
 		if (Validator.isNotNull(baseDirName)) {
 			processBuilder.directory(new File(baseDirName));
 		}
-		else if (_gitToplevel != null) {
-			processBuilder.directory(_gitToplevel);
+		else if (_gitTopLevel != null) {
+			processBuilder.directory(_gitTopLevel);
 		}
 
 		try {
@@ -688,9 +688,9 @@ public class SourceFormatterUtil {
 		List<String> lines = git(
 			Arrays.asList("rev-parse", "--show-toplevel"), null, null, false);
 
-		_gitToplevel = new File(lines.get(0));
+		_gitTopLevel = new File(lines.get(0));
 
-		String absolutePath = _gitToplevel.getAbsolutePath();
+		String absolutePath = _gitTopLevel.getAbsolutePath();
 
 		git(
 			Arrays.asList(
@@ -744,7 +744,7 @@ public class SourceFormatterUtil {
 				pathMatchers, includeSubrepositories,
 				line -> gitFiles.add(
 					StringBundler.concat(
-						_gitToplevel, StringPool.FORWARD_SLASH,
+						_gitTopLevel, StringPool.FORWARD_SLASH,
 						StringUtil.replace(
 							line, CharPool.BACK_SLASH, CharPool.SLASH))));
 
@@ -892,7 +892,7 @@ public class SourceFormatterUtil {
 
 	private static final FileSystem _fileSystem = FileSystems.getDefault();
 	private static Boolean _git;
-	private static File _gitToplevel;
+	private static File _gitTopLevel;
 	private static List<String> _sfIgnoreDirectories;
 	private static List<String> _subrepoIgnoreDirectories;
 

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/HR_Home_Page_Content_master.lar/group/43558/portlet/com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_oLvTWyFgm7p1/preferences/layout/0/31/portlet-preferences.xml
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/HR_Home_Page_Content_master.lar/group/43558/portlet/com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_oLvTWyFgm7p1/preferences/layout/0/31/portlet-preferences.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 
+
+
+
+
+
 <portlet-preferences owner-id="0" owner-type="3" default-user="false" plid="31" portlet-id="com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_oLvTWyFgm7p1">
 	<preference>
 		<name>enableComments</name>


### PR DESCRIPTION
Hi @drewbrokke Great job!

No big changes from my side.

I just have some questions.

**Q1:**
I add a test 7493da68eb78254202f049457c6e0356325973dd for testing 45538e2a0d4eff65773c34b48b610f6d775f38c3
`ant format-source-current-branch`: the file under .lar is changed by SF.
But
`ant format-source-all`: SF didn't change this file.

I still don't understand why SF gave the differerent result.

Backgroud of this code:
```
new ExcludeSyntaxPattern(
	ExcludeSyntax.REGEX,
	".*/tests?/.*/dependencies/.+\\.(jar|lar|war|zip)/.+"),
```
SF skips checks when the files are under the archive named folders.
But SF will check the archive(this archive is a real file), see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/PoshiSourceProcessor.java#L67

`Q2:`
I can see the big performance when I run `gw formatSource` in `accout-service`.
But the time for `ant format-source-all` and `ant format-source-current` looks like small(less than 30 secends), I will look into it again later.

The first important thing is Q1. Let's figure it out together.

Thanks.