### PR TITLE
LPS-190915 Fix Windows path issue

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -720,7 +720,7 @@ public class SourceFormatterUtil {
 						StringBundler.concat(
 							baseDirName, StringPool.FORWARD_SLASH,
 							StringUtil.replace(
-								line, CharPool.BACK_SLASH, CharPool.SLASH))));
+								line, CharPool.SLASH, File.separatorChar))));
 
 				return gitFiles;
 			}


### PR DESCRIPTION
Hi Drew,
On Windows OS:
For the first issue: we need to add `quotepath=false` in gitconfig.
For the second issue: see my changes.

Thanks @seiphon @qz1010 for testing on Windows.