### PR TITLE
LPS-197106 Add baseDirName for git when get top level

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -735,8 +735,8 @@ public class SourceFormatterUtil {
 
 				if (_gitTopLevelFolder == null) {
 					List<String> lines = git(
-						Arrays.asList("rev-parse", "--show-toplevel"), null,
-						null, false);
+						Arrays.asList("rev-parse", "--show-toplevel"),
+						baseDirName, null, false);
 
 					_gitTopLevelFolder = new File(lines.get(0));
 				}


### PR DESCRIPTION
Hi @drewbrokke ,  when I debug SF code and give a specific BaseDirName, I always get a wrong git top level dir. I found if I give the 'baseDirName' value to git method, it can be fixed. is that  a bug?