### PR TITLE
site initializer dir

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -263,8 +263,12 @@ public class ClientExtensionProjectConfigurator
 
 						if (clientExtension.type.equals("siteInitializer")) {
 							buildSiteInitializerZipTaskProvider.configure(
-								zip -> zip.from(
-									project.file("site-initializer")));
+								zip -> {
+									zip.from(
+										project.file("site-initializer"));
+									zip.into("site-initializer");
+								}
+							);
 						}
 					}
 					catch (JsonProcessingException jsonProcessingException) {


### PR DESCRIPTION
- LPS-199357 Show all articles like we did for LPS-196604
- LPS-199357 We shouldn't filter asset entry rels on service layer, since we are not returning the expected values. Also, if we filter it in service layer, count and get methods don't match
- LPS-198958 include pound char to stop reference
- LPS-198958 SF
- LPS-199141 Avoid querying from the database if the first if condition is met
- LPS-199141 Better yet, let's do it this way instead. This way avoids fetching and iterating over an indefinite number of portlet preferences in the most common case. Even in the worst case, while we still have to fetch an indefinite number of portlet preferences, we don't have to iterate over them.
- LPS-199141 Exposes the count method at the service layer
- LPS-199141 BuildService
- LPS-199141 Uses the count method since we don't need the list
- LPS-199141 SF
- LPS-199141 rename
- LPS-195534 Adding a new macro in DataSetAdmin
- LPS-195534 Adding some tests DataSet Translation filters
- LPS-199167 Removes references to metal-soy and metal-soy-bundle
- LPS-199167 yarn.lock
- LPS-199346 Remove FF LPS-167253 from poshi tests
- LPS-198083 Remove webpack from svg4everybody
- LPS-198648 escape file value before using in the input. Same is done in Message Boards
- LPS-180060 Add search to ObjectEntrySelectors
- LPS-197368 make sure to include a "site-initializer" dir inside the zip
