### PR TITLE
LPS-183167 Changing a profile client-extension yaml file should make certain tasks out of date

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -218,8 +218,15 @@ public class ClientExtensionProjectConfigurator
 
 						validateClientExtensionTaskProvider.configure(
 							task -> task.doLast(
-								task1 -> _validateClientExtension(
-									clientExtension, project)));
+								new Action<Task>() {
+
+									@Override
+									public void execute(Task task1) {
+										_validateClientExtension(
+											clientExtension, project);
+									}
+
+								}));
 
 						_clientExtensionIds.compute(
 							clientExtension.id,
@@ -701,43 +708,51 @@ public class ClientExtensionProjectConfigurator
 					LifecycleBasePlugin.VERIFICATION_GROUP);
 
 				validateClientExtensionIdsTask.doFirst(
-					validateClientExtensionIdsTask1 -> {
-						StringBundler sb = new StringBundler();
+					new Action<Task>() {
 
-						File rootDir = project.getRootDir();
+						@Override
+						public void execute(
+							Task validateClientExtensionIdsTask1) {
 
-						Path rootDirPath = rootDir.toPath();
+							StringBundler sb = new StringBundler();
 
-						for (Map.Entry<String, Set<Project>> entry :
-								_clientExtensionIds.entrySet()) {
+							File rootDir = project.getRootDir();
 
-							Set<Project> projects = entry.getValue();
+							Path rootDirPath = rootDir.toPath();
 
-							if ((projects.size() > 1) &&
-								projects.contains(project)) {
+							for (Map.Entry<String, Set<Project>> entry :
+									_clientExtensionIds.entrySet()) {
 
-								sb.append("Duplicate client extension ID \"");
-								sb.append(entry.getKey());
-								sb.append("\" found in these projects:\n");
+								Set<Project> projects = entry.getValue();
 
-								for (Project curProject : projects) {
-									File projectDir =
-										curProject.getProjectDir();
+								if ((projects.size() > 1) &&
+									projects.contains(project)) {
 
 									sb.append(
-										rootDirPath.relativize(
-											projectDir.toPath()));
+										"Duplicate client extension ID \"");
+									sb.append(entry.getKey());
+									sb.append("\" found in these projects:\n");
+
+									for (Project curProject : projects) {
+										File projectDir =
+											curProject.getProjectDir();
+
+										sb.append(
+											rootDirPath.relativize(
+												projectDir.toPath()));
+
+										sb.append(StringPool.NEW_LINE);
+									}
 
 									sb.append(StringPool.NEW_LINE);
 								}
+							}
 
-								sb.append(StringPool.NEW_LINE);
+							if (sb.length() > 0) {
+								throw new GradleException(sb.toString());
 							}
 						}
 
-						if (sb.length() > 0) {
-							throw new GradleException(sb.toString());
-						}
 					});
 			});
 

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -81,6 +81,7 @@ import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskInputs;
+import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.TaskState;
 import org.gradle.api.tasks.bundling.Zip;
@@ -1102,6 +1103,25 @@ public class ClientExtensionProjectConfigurator
 			}
 
 			baseObjectNode.replace(fieldName, fieldNameOverrideJsonNode);
+		}
+	}
+
+	@SafeVarargs
+	private final void _setOutputsUpToDateAlways(
+		TaskProvider<? extends Task>... taskProviders) {
+
+		for (TaskProvider<? extends Task> taskProvider : taskProviders) {
+			taskProvider.configure(
+				new Action<Task>() {
+
+					@Override
+					public void execute(Task task) {
+						TaskOutputs outputs = task.getOutputs();
+
+						outputs.upToDateWhen(task1 -> true);
+					}
+
+				});
 		}
 	}
 

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -158,6 +158,17 @@ public class ClientExtensionProjectConfigurator
 				project, VALIDATE_CLIENT_EXTENSIONS_TASK_NAME,
 				DefaultTask.class);
 
+		_addInputFile(
+			project.file(_CLIENT_EXTENSION_YAML), () -> true,
+			assembleClientExtensionTaskProvider,
+			createClientExtensionConfigTaskProvider,
+			validateClientExtensionIdsTaskProvider,
+			validateClientExtensionTaskProvider);
+
+		_setOutputsUpToDateAlways(
+			validateClientExtensionIdsTaskProvider,
+			validateClientExtensionTaskProvider);
+
 		_baseConfigureClientExtensionProject(
 			project, assembleClientExtensionTaskProvider,
 			buildClientExtensionZipTaskProvider,
@@ -549,10 +560,6 @@ public class ClientExtensionProjectConfigurator
 					return;
 				}
 
-				TaskInputs taskInputs = assembleClientExtensionCopy.getInputs();
-
-				taskInputs.file(_CLIENT_EXTENSION_YAML);
-
 				assembleArrayNode.forEach(
 					copyJsonNode -> {
 						JsonNode fromJsonNode = copyJsonNode.get("from");
@@ -679,11 +686,6 @@ public class ClientExtensionProjectConfigurator
 					ASSEMBLE_CLIENT_EXTENSION_TASK_NAME,
 					VALIDATE_CLIENT_EXTENSION_IDS_TASK_NAME,
 					VALIDATE_CLIENT_EXTENSIONS_TASK_NAME);
-
-				TaskInputs taskInputs =
-					createClientExtensionConfigTask.getInputs();
-
-				taskInputs.file(project.file(_CLIENT_EXTENSION_YAML));
 
 				createClientExtensionConfigTask.addClientExtensionProperties(
 					_getClientExtensionProperties());

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -267,6 +267,9 @@ public class ClientExtensionProjectConfigurator
 									zip.from(project.file("site-initializer"));
 									zip.into("site-initializer");
 								});
+							createClientExtensionConfigTaskProvider.configure(
+								task -> task.dependsOn(
+									BUILD_SITE_INITIALIZER_ZIP_TASK_NAME));
 						}
 					}
 					catch (JsonProcessingException jsonProcessingException) {
@@ -643,7 +646,6 @@ public class ClientExtensionProjectConfigurator
 			createClientExtensionConfigTask -> {
 				createClientExtensionConfigTask.dependsOn(
 					ASSEMBLE_CLIENT_EXTENSION_TASK_NAME,
-					BUILD_SITE_INITIALIZER_ZIP_TASK_NAME,
 					VALIDATE_CLIENT_EXTENSION_IDS_TASK_NAME,
 					VALIDATE_CLIENT_EXTENSIONS_TASK_NAME);
 

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -180,7 +180,10 @@ public class ClientExtensionProjectConfigurator
 
 		Map<String, JsonNode> profileJsonNodes =
 			_configureClientExtensionJsonNodes(
-				project, createClientExtensionConfigTaskProvider);
+				project, assembleClientExtensionTaskProvider,
+				createClientExtensionConfigTaskProvider,
+				validateClientExtensionIdsTaskProvider,
+				validateClientExtensionTaskProvider);
 
 		for (Map.Entry<String, JsonNode> profileJsonNodeEntry :
 				profileJsonNodes.entrySet()) {
@@ -615,10 +618,9 @@ public class ClientExtensionProjectConfigurator
 			});
 	}
 
-	private Map<String, JsonNode> _configureClientExtensionJsonNodes(
-		Project project,
-		TaskProvider<CreateClientExtensionConfigTask>
-			createClientExtensionConfigTaskProvider) {
+	@SafeVarargs
+	private final Map<String, JsonNode> _configureClientExtensionJsonNodes(
+		Project project, TaskProvider<? extends Task>... taskProviders) {
 
 		Map<String, JsonNode> profileJsonNodes = new HashMap<>();
 
@@ -661,12 +663,9 @@ public class ClientExtensionProjectConfigurator
 
 			profileJsonNodes.put(profileName, jsonNode);
 
-			createClientExtensionConfigTaskProvider.configure(
-				task -> {
-					TaskInputs taskInputs = task.getInputs();
-
-					taskInputs.file(file);
-				});
+			_addInputFile(
+				file, () -> _isActiveProfile(project, profileName),
+				taskProviders);
 		}
 
 		return profileJsonNodes;

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -53,6 +53,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -445,6 +446,28 @@ public class ClientExtensionProjectConfigurator
 			project, LifecycleBasePlugin.CLEAN_TASK_NAME);
 
 		cleanTask.dependsOn(dockerRemoveImage);
+	}
+
+	@SafeVarargs
+	private final void _addInputFile(
+		File inputFile, Supplier<Boolean> supplier,
+		TaskProvider<? extends Task>... taskProviders) {
+
+		for (TaskProvider<? extends Task> taskProvider : taskProviders) {
+			taskProvider.configure(
+				new Action<Task>() {
+
+					@Override
+					public void execute(Task task) {
+						if (supplier.get()) {
+							TaskInputs inputs = task.getInputs();
+
+							inputs.file(inputFile);
+						}
+					}
+
+				});
+		}
 	}
 
 	private TaskProvider<Zip> _baseConfigureClientExtensionProject(

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/task/CreateClientExtensionConfigTask.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/task/CreateClientExtensionConfigTask.java
@@ -56,6 +56,7 @@ import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskOutputs;
 
@@ -180,12 +181,12 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 		_createClientExtensionConfigFile(jsonMap);
 	}
 
-	@InputFiles
+	@OutputFile
 	public File getClientExtensionConfigFile() {
 		return GradleUtil.toFile(_project, _clientExtensionConfigFile);
 	}
 
-	@InputFiles
+	@OutputFile
 	public File getDockerFile() {
 		return GradleUtil.toFile(_project, _dockerFile);
 	}
@@ -205,17 +206,17 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 		return GradleUtil.toFile(_project, "liferay-plugin-package.properties");
 	}
 
-	@InputFiles
+	@OutputFile
 	public File getLcpJsonFile() {
 		return GradleUtil.toFile(_project, _lcpJsonFile);
 	}
 
-	@InputFiles
+	@OutputFile
 	public File getPluginPackagePropertiesFile() {
 		return GradleUtil.toFile(_project, _pluginPackagePropertiesFile);
 	}
 
-	@InputFiles
+	@OutputFile
 	public File getSiteInitializerJsonFile() {
 		return GradleUtil.toFile(_project, _siteInitializerJsonFile);
 	}

--- a/modules/sdk/gradle-plugins-workspace/src/main/resources/com/liferay/gradle/plugins/workspace/task/packageinfo
+++ b/modules/sdk/gradle-plugins-workspace/src/main/resources/com/liferay/gradle/plugins/workspace/task/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.0.1


### PR DESCRIPTION
This is an update for [LPS-183167](https://issues.liferay.com/browse/LPS-183167).

This pull fixes a number of issues with Gradle's incremental build when building/deploying client extensions. Some highlights:
- Fixes incorrectly annotated outputs in `CreateClientExtensionConfigTask`
- Conditionally include the `buildSiteInitializerZip` task rather than always including as a no-op
- Replaces lambdas with anonymous classes for `doLast`/`doFirst` statements so that Gradle's incremental build is not automatically invalidated. See [Gradle's docs on validation_problems.html#implementation_unknown](https://docs.gradle.org/7.3.3/userguide/validation_problems.html#implementation_unknown)
- Declares the validation tasks' outputs as always up-to-date since they don't produce any output
- Moves all declarations of `client-extension.yaml` as an input to a single location
- Conditionally declares the profile `yaml` files as inputs so that things will properly re-build when switching between different deploy profile tasks

FYI @gamerson @rotty3000 @petershin