### PR TITLE
POSHI-662 Go-to-definition does not work for macros with new macro definition syntax

### DIFF
--- a/modules/test/poshi/poshi-vscode/CHANGELOG.markdown
+++ b/modules/test/poshi/poshi-vscode/CHANGELOG.markdown
@@ -5,6 +5,7 @@
 - Reduces package size
 - Adds a license
 - Moves release notes to CHANGELOG.markdown
+- POSHI-662: Adds support for new macro definition syntax
 
 ## [0.3.1] - [0.3.6]
 

--- a/modules/test/poshi/poshi-vscode/package.json
+++ b/modules/test/poshi/poshi-vscode/package.json
@@ -122,6 +122,16 @@
 		"node": ">=16",
 		"vscode": "^1.64.0"
 	},
+	"eslintConfig": {
+		"overrides": [
+			{
+				"files": ["*.ts"],
+				"rules": {
+					"@liferay/no-extraneous-dependencies": "off"
+				}
+			}
+		]
+	},
 	"icon": "images/icon.png",
 	"keywords": [
 		"liferay",

--- a/modules/test/poshi/poshi-vscode/package.json
+++ b/modules/test/poshi/poshi-vscode/package.json
@@ -125,7 +125,10 @@
 	"eslintConfig": {
 		"overrides": [
 			{
-				"files": ["*.mjs", "*.ts"],
+				"files": [
+					"*.mjs",
+					"*.ts"
+				],
 				"rules": {
 					"@liferay/no-extraneous-dependencies": "off"
 				}

--- a/modules/test/poshi/poshi-vscode/package.json
+++ b/modules/test/poshi/poshi-vscode/package.json
@@ -151,7 +151,7 @@
 		"compile": "npm run esbuild-base -- --sourcemap",
 		"esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --external:@vscode/ripgrep --format=cjs --platform=node",
 		"esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
-		"format": "prettier --write 'src/**/*.ts'",
+		"format": "prettier --write 'package.json' 'scripts/*.mjs' 'src/**/*.ts'",
 		"generate-license": "node scripts/generate_license.mjs",
 		"lint": "eslint src --ext ts",
 		"lint:fix": "eslint src --ext ts --fix",

--- a/modules/test/poshi/poshi-vscode/package.json
+++ b/modules/test/poshi/poshi-vscode/package.json
@@ -125,7 +125,7 @@
 	"eslintConfig": {
 		"overrides": [
 			{
-				"files": ["*.ts"],
+				"files": ["*.mjs", "*.ts"],
 				"rules": {
 					"@liferay/no-extraneous-dependencies": "off"
 				}

--- a/modules/test/poshi/poshi-vscode/scripts/generate_license.mjs
+++ b/modules/test/poshi/poshi-vscode/scripts/generate_license.mjs
@@ -1,15 +1,6 @@
 /**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 import {spawnSync} from 'node:child_process';

--- a/modules/test/poshi/poshi-vscode/src/lib/languageFeatureProviders/DefinitionProviderImpl.ts
+++ b/modules/test/poshi/poshi-vscode/src/lib/languageFeatureProviders/DefinitionProviderImpl.ts
@@ -83,6 +83,10 @@ export class DefinitionProviderImpl implements vscode.DefinitionProvider {
 						`**/${fileName}.{function,macro}`,
 						`(?:macro|function) (${methodName}) \\{`
 					),
+					getMethodLocations(
+						`**/${fileName}.macro`,
+						`macro (${methodName})\\(`
+					),
 				]);
 
 				return result.flat();

--- a/modules/test/poshi/poshi-vscode/src/lib/tokens.ts
+++ b/modules/test/poshi/poshi-vscode/src/lib/tokens.ts
@@ -14,7 +14,7 @@ const tokenPatternMap = {
 	pathLocator: /"([A-Z][\w-]+)#([A-Z][A-Z0-9_-]+)"/g,
 	className: /[^\w.]([A-Z][\w-]+)[(.]/g,
 	methodInvocation: /[^\w.]([A-Z][\w-]+)\.([\w-]+)/g,
-	methodDefinition: /(?:macro|function) ([\w-]+) \{/g,
+	methodDefinition: /(?:macro|function) ([\w-]+)(?:\(| \{)/g,
 	liferaySelenium: /[^\w.](selenium)[.]/g,
 	liferaySeleniumMethod: /[^\w.](selenium)\.([A-Za-z_][A-Za-z]+)/g,
 };

--- a/modules/test/poshi/poshi-vscode/src/test/tokens.spec.ts
+++ b/modules/test/poshi/poshi-vscode/src/test/tokens.spec.ts
@@ -55,18 +55,23 @@ const tokenTypeTestCases: {[K in TokenType]: TestCase[]} = {
 	methodDefinition: [
 		{
 			expectedMatchText: ['fooBar'],
-			input: 'macro |fooBar {',
+			input: 'macro |fooBar(',
 			optionalDescription: 'macro',
 		},
 		{
 			expectedMatchText: ['fooBar'],
-			input: 'macro fooBar| {',
+			input: 'macro fooBar|(',
 			optionalDescription: 'macro with cursor at the end',
 		},
 		{
 			expectedMatchText: ['foo-Bar_Baz8'],
-			input: 'macro |foo-Bar_Baz8 {',
+			input: 'macro |foo-Bar_Baz8(',
 			optionalDescription: 'macro with numbers and special characters',
+		},
+		{
+			expectedMatchText: ['fooBar'],
+			input: 'macro |fooBar {',
+			optionalDescription: 'macro with legacy syntax',
 		},
 		{
 			expectedMatchText: ['fooBar'],


### PR DESCRIPTION
This is an update for [POSHI-662](https://issues.liferay.com/browse/POSHI-662).