### PR TITLE
POSHI-662 Go-to-definition does not work for macros with new macro definition syntax

### DIFF
--- a/.github/workflows/build-poshi-vscode-extension.yaml
+++ b/.github/workflows/build-poshi-vscode-extension.yaml
@@ -31,10 +31,6 @@ jobs:
                       npm_config_arch: x64
                       os: windows-latest
                       platform: win32
-                    - arch: ia32
-                      npm_config_arch: ia32
-                      os: windows-latest
-                      platform: win32
                     - arch: arm64
                       npm_config_arch: arm
                       os: windows-latest

--- a/.github/workflows/build-poshi-vscode-extension.yaml
+++ b/.github/workflows/build-poshi-vscode-extension.yaml
@@ -51,6 +51,10 @@ jobs:
                       npm_config_arch: x64
                       os: ubuntu-latest
                       platform: alpine
+                    - arch: arm64
+                      npm_config_arch: arm64
+                      os: ubuntu-latest
+                      platform: alpine
                     - arch: x64
                       npm_config_arch: x64
                       os: macos-latest

--- a/modules/test/poshi/poshi-vscode/CHANGELOG.md
+++ b/modules/test/poshi/poshi-vscode/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## [0.3.9]
+
 ## [0.3.8]
 
 - Fixes broken Marketplace presentation issues

--- a/modules/test/poshi/poshi-vscode/package.json
+++ b/modules/test/poshi/poshi-vscode/package.json
@@ -166,7 +166,7 @@
 		"vscode:prepublish": "npm run esbuild-base -- --minify && npm run generate-license",
 		"watch": "tsc -watch -p ./"
 	},
-	"version": "0.3.8",
+	"version": "0.3.9",
 	"vsce": {
 		"baseImagesUrl": "https://github.com/liferay/liferay-portal/raw/HEAD/modules/test/poshi/poshi-vscode"
 	}


### PR DESCRIPTION
This is an update for [POSHI-662](https://issues.liferay.com/browse/POSHI-662).