### PR TITLE
[TS] LPD-17832 2023.q4 branch is broken: 2023.q4.5 identifies as q4.1

### DIFF
--- a/release.properties
+++ b/release.properties
@@ -129,8 +129,8 @@
     release.info.version.display.name[7.3.x-private]=7.3.10 SP3
     release.info.version.display.name[7.4.x-private]=${release.info.version.display.name[master-private]}
     release.info.version.display.name[master-private]=7.4.13 Update ${release.info.version.update}
-    release.info.version.display.name[release-2023.q3-private]=2023.Q3.1
-    release.info.version.display.name[release-2023.q4-private]=2023.Q4.1
+    release.info.version.display.name[release-2023.q3-private]=2023.Q3.7
+    release.info.version.display.name[release-2023.q4-private]=2023.Q4.5
 
     release.info.version.file.suffix[7.0.x-private]=-ga1
     release.info.version.file.suffix[7.1.x-private]=-ga1


### PR DESCRIPTION
Hi @drewbrokke 

Could you please review this pull request?

**Please note that this issue is critical as it disables hotfixing for this version.**

Motivation
=======
**2023.q4.5** was released, however, it identifies as **q4.1**. The commit 97de7dbd14a6ec050c320513a2d357b73fee32f3 caused this problem.

Proposed Solution
========
Setting the correct latest release versions for `release.info.version.display.name[release-2023.q3-private]` and `release.info.version.display.name[release-2023.q4-private]`.

Steps to Verify
========
Please see the linked LPD for the reproduction steps.
https://liferay.atlassian.net/browse/LPD-17832

Thank you and best regards,
István