### PR TITLE
LPD-100291 Avoid Tomcat fingerprinting by removing all content

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -1012,9 +1012,15 @@ org.apache.level=WARNING]]>
 			file="${app.server.tomcat.dir}/conf/server.xml"
 		>
 			<replacetoken><![CDATA[pattern="%h %l %u %t &quot;%r&quot; %s %b" />]]></replacetoken>
-			<replacevalue><![CDATA[pattern="%h %l %u %t &quot;%r&quot; %s %b" />-->
-				<Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />]]>
-			</replacevalue>
+			<replacevalue><![CDATA[pattern="%h %l %u %t &quot;%r&quot; %s %b" />-->]]></replacevalue>
+		</replace>
+
+		<replace
+			failOnNoReplacements="true"
+			file="${app.server.tomcat.dir}/conf/server.xml"
+		>
+			<replacetoken><![CDATA[unpackWARs="true" autoDeploy="true">]]></replacetoken>
+			<replacevalue><![CDATA[unpackWARs="true" autoDeploy="true" errorReportValveClass="">]]></replacevalue>
 		</replace>
 
 		<replace


### PR DESCRIPTION
Hi @drewbrokke , I hope you are the correct person to send this to.

It basically removes the ErrorValve. This valve was adding Tomcat specific content when DXP didn't provide own error message. The goal is to remove any tomcat specifics so that attackers can't say it's even running Tomcat behind.

Please let me know if you need more information or I should forward to somebody else.

Thank you!